### PR TITLE
Updated logging from DEBUG to INFO

### DIFF
--- a/consistency-checker/src/test/resources/simplelogger.properties
+++ b/consistency-checker/src/test/resources/simplelogger.properties
@@ -1,1 +1,1 @@
-org.slf4j.simpleLogger.defaultLogLevel=DEBUG
+org.slf4j.simpleLogger.defaultLogLevel=INFO


### PR DESCRIPTION
Cuts down on logging, which is causing https://github.com/lightblue-platform/lightblue/pull/19 to fail building on travis.