### PR TITLE
Handle NullNode case

### DIFF
--- a/consistency-checker/src/main/java/com/redhat/lightblue/migrator/consistency/MigrationJob.java
+++ b/consistency-checker/src/main/java/com/redhat/lightblue/migrator/consistency/MigrationJob.java
@@ -379,8 +379,8 @@ public class MigrationJob implements Runnable {
                 JsonNode sourceNode = sourceEntry.getValue();
                 JsonNode destinationNode = destinationDocument.findValue(sourceEntry.getKey());
 
-                if((sourceNode == null || JsonNodeType.NULL.equals(sourceNode.getNodeType())
-                        && (destinationNode == null || JsonNodeType.NULL.equals(destinationNode.getNodeType())))) {
+                if((sourceNode == null || JsonNodeType.NULL.equals(sourceNode.getNodeType()))
+                        && (destinationNode == null || JsonNodeType.NULL.equals(destinationNode.getNodeType()))) {
                     continue;
                 }
                 if(!sourceNode.equals(destinationNode)) {

--- a/consistency-checker/src/main/java/com/redhat/lightblue/migrator/consistency/MigrationJob.java
+++ b/consistency-checker/src/main/java/com/redhat/lightblue/migrator/consistency/MigrationJob.java
@@ -379,8 +379,8 @@ public class MigrationJob implements Runnable {
                 JsonNode sourceNode = sourceEntry.getValue();
                 JsonNode destinationNode = destinationDocument.findValue(sourceEntry.getKey());
 
-                if((JsonNodeType.NULL.equals(sourceNode.getNodeType())
-                        && destinationNode == null)){
+                if((sourceNode == null || JsonNodeType.NULL.equals(sourceNode.getNodeType())
+                        && (destinationNode == null || JsonNodeType.NULL.equals(destinationNode.getNodeType())))) {
                     continue;
                 }
                 if(!sourceNode.equals(destinationNode)) {

--- a/consistency-checker/src/main/java/com/redhat/lightblue/migrator/consistency/MigrationJob.java
+++ b/consistency-checker/src/main/java/com/redhat/lightblue/migrator/consistency/MigrationJob.java
@@ -19,6 +19,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeType;
 import com.redhat.lightblue.client.LightblueClient;
 import com.redhat.lightblue.client.enums.SortDirection;
 import com.redhat.lightblue.client.expression.query.Query;
@@ -371,9 +372,18 @@ public class MigrationJob implements Runnable {
         Iterator<Entry<String, JsonNode>> nodeIterator = sourceDocument.fields();
 
         while (nodeIterator.hasNext()) {
-            Entry<String, JsonNode> sourceNode = nodeIterator.next();
-            if(!getJobConfiguration().getComparisonExclusionPaths().contains(sourceNode.getKey())) {
-                if(!sourceNode.getValue().equals(destinationDocument.findValue(sourceNode.getKey()))) {
+            Entry<String, JsonNode> sourceEntry = nodeIterator.next();
+
+            List<String> excludes = getJobConfiguration().getComparisonExclusionPaths();
+            if(excludes == null || !excludes.contains(sourceEntry.getKey())) {
+                JsonNode sourceNode = sourceEntry.getValue();
+                JsonNode destinationNode = destinationDocument.findValue(sourceEntry.getKey());
+
+                if((JsonNodeType.NULL.equals(sourceNode.getNodeType())
+                        && destinationNode == null)){
+                    continue;
+                }
+                if(!sourceNode.equals(destinationNode)) {
                     consistent = false;
                     break;
                 }

--- a/consistency-checker/src/test/java/com/redhat/lightblue/migrator/consistency/MigrationJobTest.java
+++ b/consistency-checker/src/test/java/com/redhat/lightblue/migrator/consistency/MigrationJobTest.java
@@ -68,7 +68,7 @@ public class MigrationJobTest {
      * If source = NullNode and destinationValue = null, then consider equivalent.
      */
     @Test
-    public void testDocumentsConsistent_With_SourceNullNode_And_Destination_NullValue(){
+    public void testDocumentsConsistent_With_Source_NullNode_And_Destination_NullValue(){
         JsonNodeFactory factory = JsonNodeFactory.withExactBigDecimals(false);
         ObjectNode sourceNode = factory.objectNode();
         sourceNode.put("somekey", NullNode.getInstance());
@@ -79,10 +79,26 @@ public class MigrationJobTest {
     }
 
     /**
+     * If source = null and destinationValue = NullNode, then consider equivalent.
+     */
+    @Test
+    public void testDocumentsConsistent_With_Source_NullValue_And_Destination_NullNode(){
+        JsonNodeFactory factory = JsonNodeFactory.withExactBigDecimals(false);
+        ObjectNode sourceNode = factory.objectNode();
+        String nullString = null;
+        sourceNode.put("somekey", nullString);
+
+        ObjectNode destNode = factory.objectNode();
+        destNode.put("somekey", NullNode.getInstance());
+
+        assertTrue(migrationJob.documentsConsistent(sourceNode, destNode));
+    }
+
+    /**
      * If source = NullNode and destinationValue has a value, then consider inconsistent.
      */
     @Test
-    public void testDocumentsConsistent_With_SourceNullNode_But_DestinationHasAValue(){
+    public void testDocumentsConsistent_With_Source_NullNode_But_Destination_HasAValue(){
         JsonNodeFactory factory = JsonNodeFactory.withExactBigDecimals(false);
         ObjectNode sourceNode = factory.objectNode();
         sourceNode.put("somekey", NullNode.getInstance());
@@ -94,7 +110,22 @@ public class MigrationJobTest {
     }
 
     /**
-     * If source = NullNode and destinationValue = null, then consider equivalent.
+     * If source has a value and destinationValue = NullNode, then consider inconsistent.
+     */
+    @Test
+    public void testDocumentsConsistent_With_Source_HasAValue_But_Destination_NullNode(){
+        JsonNodeFactory factory = JsonNodeFactory.withExactBigDecimals(false);
+        ObjectNode sourceNode = factory.objectNode();
+        sourceNode.put("somekey", factory.textNode("someValue"));
+
+        ObjectNode destNode = factory.objectNode();
+        destNode.put("somekey", NullNode.getInstance());
+
+        assertFalse(migrationJob.documentsConsistent(sourceNode, destNode));
+    }
+
+    /**
+     * If source = some value and destinationValue = some other value, then consider equivalent.
      */
     @Test
     public void testDocumentsConsistent_SourceAndDestinationNotConsistent(){


### PR DESCRIPTION
This change will help the consistency checker better handle NullNodes.

Also handle the case when ComparisonExclusionPaths is null.

Added supporting unit tests.