### PR TITLE
remove redundancy in name

### DIFF
--- a/consistency-checker/pom.xml
+++ b/consistency-checker/pom.xml
@@ -148,7 +148,7 @@
               </execution>
             </executions>
             <configuration>
-              <name>lightblue-${project.artifactId}</name>
+              <name>${project.artifactId}</name>
               <copyright>Red Hat</copyright>
               <distribution>RHEL</distribution>
               <group>Lightblue Platform</group>


### PR DESCRIPTION
I suspect this problem started when we changed artifactId to starting with 'lightblue'. At any rate, this fixes the rpm name from being lightblue-lightblue-...