### PR TITLE
use correct daemon version

### DIFF
--- a/consistency-checker/pom.xml
+++ b/consistency-checker/pom.xml
@@ -63,7 +63,7 @@
     <dependency>
       <groupId>commons-daemon</groupId>
       <artifactId>commons-daemon</artifactId>
-      <version>1.0.15</version>
+      <version>1.0.10</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
Migrator is currently building with a newer version of the client then what is on the server. Simply making the version number match.