### PR TITLE
use alldeps jar for rpm

### DIFF
--- a/consistency-checker/pom.xml
+++ b/consistency-checker/pom.xml
@@ -161,7 +161,7 @@
                   <directory>${rpm.install.basedir}</directory>
                   <sources>
                     <source>
-                      <location>target/${project.artifactId}-${project.version}.${project.packaging}</location>
+                      <location>target/${project.artifactId}-${project.version}-alldeps.${project.packaging}</location>
                     </source>
                   </sources>
                 </mapping>


### PR DESCRIPTION
This fixes an issue where jsvc was unable to find embedded dependencies.