### PR TITLE
don't attempt to fetch destination documents if there are no source documents

### DIFF
--- a/consistency-checker/src/main/java/com/redhat/lightblue/migrator/consistency/MigrationJob.java
+++ b/consistency-checker/src/main/java/com/redhat/lightblue/migrator/consistency/MigrationJob.java
@@ -336,7 +336,7 @@ public class MigrationJob implements Runnable {
     protected Map<String, JsonNode> getDestinationDocuments(Map<String, JsonNode> sourceDocuments) {
         Map<String, JsonNode> destinationDocuments = new LinkedHashMap<>();
         if(sourceDocuments == null || sourceDocuments.isEmpty()){
-            LOGGER.warn("Unable to fetch any destination documents as there are no source documents");
+            LOGGER.info("Unable to fetch any destination documents as there are no source documents");
             return destinationDocuments;
         }
 

--- a/consistency-checker/src/main/java/com/redhat/lightblue/migrator/consistency/MigrationJob.java
+++ b/consistency-checker/src/main/java/com/redhat/lightblue/migrator/consistency/MigrationJob.java
@@ -335,6 +335,11 @@ public class MigrationJob implements Runnable {
 
     protected Map<String, JsonNode> getDestinationDocuments(Map<String, JsonNode> sourceDocuments) {
         Map<String, JsonNode> destinationDocuments = new LinkedHashMap<>();
+        if(sourceDocuments == null || sourceDocuments.isEmpty()){
+            LOGGER.warn("Unable to fetch any destination documents as there are no source documents");
+            return destinationDocuments;
+        }
+
         try {
             DataFindRequest destinationRequest = new DataFindRequest(getJobConfiguration().getDestinationEntityName(), getJobConfiguration().getDestinationEntityVersion());
             List<Query> requestConditions = new LinkedList<>();


### PR DESCRIPTION
write a warn message as opposed to an ugly exception