### PR TITLE
If source has more than 100 documents, then call destination in batches.

### DIFF
--- a/consistency-checker/pom.xml
+++ b/consistency-checker/pom.xml
@@ -77,6 +77,12 @@
       <version>1.3.0-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
+   <dependency>
+       <groupId>org.mockito</groupId>
+       <artifactId>mockito-core</artifactId>
+       <version>1.10.19</version>
+       <scope>test</scope>
+   </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/consistency-checker/src/main/java/com/redhat/lightblue/migrator/consistency/MigrationJob.java
+++ b/consistency-checker/src/main/java/com/redhat/lightblue/migrator/consistency/MigrationJob.java
@@ -8,7 +8,9 @@ import static com.redhat.lightblue.client.projection.FieldProjection.includeFiel
 import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
@@ -345,7 +347,31 @@ public class MigrationJob implements Runnable {
     protected Map<String, JsonNode> getDestinationDocuments(Map<String, JsonNode> sourceDocuments) {
         Map<String, JsonNode> destinationDocuments = new LinkedHashMap<>();
         if(sourceDocuments == null || sourceDocuments.isEmpty()){
-            LOGGER.info("Unable to fetch any destination documents as there are no source documents");
+            //LOGGER.info("Unable to fetch any destination documents as there are no source documents");
+            return destinationDocuments;
+        }
+
+        if(sourceDocuments.size() <= 100){
+            return doDestinationDocumentFetch(sourceDocuments);
+        }
+
+        List<String> keys = Arrays.asList(sourceDocuments.keySet().toArray(new String[0]));
+        int position = 0;
+        while(position <= keys.size()){
+            Map<String, JsonNode> batch = new HashMap<String, JsonNode>();
+            List<String> subKeys = keys.subList(position, position += 100);
+            for(String subKey : subKeys){
+                batch.put(subKey, sourceDocuments.get(subKey));
+            }
+            destinationDocuments.putAll(doDestinationDocumentFetch(batch));
+        }
+
+        return destinationDocuments;
+    }
+
+    private Map<String, JsonNode> doDestinationDocumentFetch(Map<String, JsonNode> sourceDocuments){
+        Map<String, JsonNode> destinationDocuments = new LinkedHashMap<>();
+        if(sourceDocuments == null || sourceDocuments.isEmpty()){
             return destinationDocuments;
         }
 

--- a/consistency-checker/src/main/java/com/redhat/lightblue/migrator/consistency/MigrationJob.java
+++ b/consistency-checker/src/main/java/com/redhat/lightblue/migrator/consistency/MigrationJob.java
@@ -48,6 +48,8 @@ public class MigrationJob implements Runnable {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MigrationJob.class);
 
+    protected static final int BATCH_SIZE = 100;
+
     public MigrationJob() {
         migrationConfiguration = new MigrationConfiguration();
     }
@@ -351,7 +353,7 @@ public class MigrationJob implements Runnable {
             return destinationDocuments;
         }
 
-        if(sourceDocuments.size() <= 100){
+        if(sourceDocuments.size() <= BATCH_SIZE){
             return doDestinationDocumentFetch(sourceDocuments);
         }
 
@@ -359,7 +361,13 @@ public class MigrationJob implements Runnable {
         int position = 0;
         while(position <= keys.size()){
             Map<String, JsonNode> batch = new HashMap<String, JsonNode>();
-            List<String> subKeys = keys.subList(position, position += 100);
+
+            int limitedPosition = position + BATCH_SIZE;
+            if(limitedPosition > keys.size()){
+                limitedPosition = keys.size();
+            }
+
+            List<String> subKeys = keys.subList(position, limitedPosition);
             for(String subKey : subKeys){
                 batch.put(subKey, sourceDocuments.get(subKey));
             }

--- a/consistency-checker/src/main/java/com/redhat/lightblue/migrator/consistency/MigrationJob.java
+++ b/consistency-checker/src/main/java/com/redhat/lightblue/migrator/consistency/MigrationJob.java
@@ -349,7 +349,7 @@ public class MigrationJob implements Runnable {
     protected Map<String, JsonNode> getDestinationDocuments(Map<String, JsonNode> sourceDocuments) {
         Map<String, JsonNode> destinationDocuments = new LinkedHashMap<>();
         if(sourceDocuments == null || sourceDocuments.isEmpty()){
-            //LOGGER.info("Unable to fetch any destination documents as there are no source documents");
+            LOGGER.info("Unable to fetch any destination documents as there are no source documents");
             return destinationDocuments;
         }
 

--- a/consistency-checker/src/main/java/com/redhat/lightblue/migrator/consistency/MigrationJob.java
+++ b/consistency-checker/src/main/java/com/redhat/lightblue/migrator/consistency/MigrationJob.java
@@ -359,19 +359,21 @@ public class MigrationJob implements Runnable {
 
         List<String> keys = Arrays.asList(sourceDocuments.keySet().toArray(new String[0]));
         int position = 0;
-        while(position <= keys.size()){
-            Map<String, JsonNode> batch = new HashMap<String, JsonNode>();
-
+        while(position < keys.size()){
             int limitedPosition = position + BATCH_SIZE;
             if(limitedPosition > keys.size()){
                 limitedPosition = keys.size();
             }
 
             List<String> subKeys = keys.subList(position, limitedPosition);
+            Map<String, JsonNode> batch = new HashMap<String, JsonNode>();
             for(String subKey : subKeys){
                 batch.put(subKey, sourceDocuments.get(subKey));
             }
-            destinationDocuments.putAll(doDestinationDocumentFetch(batch));
+
+            Map<String, JsonNode> batchRestuls = doDestinationDocumentFetch(batch);
+            destinationDocuments.putAll(batchRestuls);
+            position = limitedPosition;
         }
 
         return destinationDocuments;

--- a/consistency-checker/src/test/java/com/redhat/lightblue/migrator/consistency/MigrationJobTest.java
+++ b/consistency-checker/src/test/java/com/redhat/lightblue/migrator/consistency/MigrationJobTest.java
@@ -8,7 +8,6 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
@@ -391,7 +390,6 @@ public class MigrationJobTest {
         when(destinationClientMock.data(any(LightblueRequest.class), eq(JsonNode[].class))).thenReturn(destinationDocuments);
 
         Map<String, JsonNode> actual = migrationJob.getDestinationDocuments(sourceDocuments);
-        verify(destinationClientMock);
 
         assertNotNull(actual);
         assertTrue(actual.containsKey("\"" + value + "\"|||"));
@@ -425,7 +423,6 @@ public class MigrationJobTest {
         .thenReturn(destinationDocumentsBatch2);
 
         Map<String, JsonNode> actual = migrationJob.getDestinationDocuments(sourceDocuments);
-        verify(destinationClientMock);
 
         assertNotNull(actual);
         assertTrue(actual.containsKey("\"" + value + "1\"|||"));
@@ -458,7 +455,6 @@ public class MigrationJobTest {
         .thenReturn(destinationDocumentsBatch2);
 
         Map<String, JsonNode> actual = migrationJob.getDestinationDocuments(sourceDocuments);
-        verify(destinationClientMock);
 
         assertNotNull(actual);
         assertTrue(actual.containsKey("\"" + value + "1\"|||"));


### PR DESCRIPTION
This is to address this exception that we were sometimes getting and I believe leading to other issues. This fix could probably use some optimization, but this is my first attempt.

```
2015-03-03 14:55:33,826 [hystrix-FindCommand-10] ERROR [com.redhat.lightblue.crud.mongo.MongoCRUDController] response too long: 1952531556: java.lang.IllegalArgumentException: response too long: 1952531556
	at com.mongodb.Response.<init>(Response.java:49)
	at com.mongodb.DBPort$1.execute(DBPort.java:141)
	at com.mongodb.DBPort$1.execute(DBPort.java:135)
	at com.mongodb.DBPort.doOperation(DBPort.java:164)
	at com.mongodb.DBPort.call(DBPort.java:135)
	at com.mongodb.DBTCPConnector.innerCall(DBTCPConnector.java:292)
	at com.mongodb.DBTCPConnector.call(DBTCPConnector.java:271)
	at com.mongodb.DBCollectionImpl.find(DBCollectionImpl.java:84)
	at com.mongodb.DB.command(DB.java:317)
	at com.mongodb.DB.command(DB.java:296)
	at com.mongodb.DBCollection.getCount(DBCollection.java:1189)
	at com.mongodb.DBCursor.size(DBCursor.java:689)
	at com.redhat.lightblue.crud.mongo.BasicDocFinder.find(BasicDocFinder.java:66)
	at com.redhat.lightblue.crud.mongo.MongoCRUDController.find(MongoCRUDController.java:380)
	at com.redhat.lightblue.mediator.SimpleFindImpl.find(SimpleFindImpl.java:52)
	at com.redhat.lightblue.mediator.Mediator.find(Mediator.java:343)
	at com.redhat.lightblue.rest.crud.hystrix.FindCommand.run(FindCommand.java:66)
	at com.redhat.lightblue.rest.crud.hystrix.FindCommand.run(FindCommand.java:36)
	at com.netflix.hystrix.HystrixCommand$HystrixCommandFromObservableCommand$1.call(HystrixCommand.java:355)
	at com.netflix.hystrix.HystrixCommand$HystrixCommandFromObservableCommand$1.call(HystrixCommand.java:350)
	at rx.Observable$2.call(Observable.java:173)
	at rx.Observable$2.call(Observable.java:166)
	at rx.Observable.unsafeSubscribe(Observable.java:8587)
	at com.netflix.hystrix.HystrixObservableCommand$4.call(HystrixObservableCommand.java:419)
	at com.netflix.hystrix.HystrixObservableCommand$4.call(HystrixObservableCommand.java:405)
	at rx.Observable.unsafeSubscribe(Observable.java:8587)
	at rx.internal.operators.OperatorSubscribeOn$1$1.call(OperatorSubscribeOn.java:62)
	at com.netflix.hystrix.strategy.concurrency.HystrixContexSchedulerAction$1.call(HystrixContexSchedulerAction.java:56)
	at com.netflix.hystrix.strategy.concurrency.HystrixContexSchedulerAction$1.call(HystrixContexSchedulerAction.java:47)
	at com.netflix.hystrix.strategy.concurrency.HystrixContexSchedulerAction.call(HystrixContexSchedulerAction.java:69)
	at com.netflix.hystrix.strategy.concurrency.HystrixContextScheduler$ThreadPoolWorker$1.run(HystrixContextScheduler.java:165)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:471)
	at java.util.concurrent.FutureTask.run(FutureTask.java:262)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
	at java.lang.Thread.run(Thread.java:745)
```