### PR TITLE
log when an error response is returned

### DIFF
--- a/consistency-checker/src/main/java/com/redhat/lightblue/migrator/consistency/MigrationJob.java
+++ b/consistency-checker/src/main/java/com/redhat/lightblue/migrator/consistency/MigrationJob.java
@@ -538,6 +538,9 @@ public class MigrationJob implements Runnable {
 
     protected LightblueResponse callLightblue(LightblueRequest request) {
         LightblueResponse response = getDestinationClient().data(request);
+        if(response.hasError()){
+            throw new RuntimeException("Error returned in response " + response.getText() + " for request " + request.getBody());
+        }
         return response;
     }
 


### PR DESCRIPTION
Depends on https://github.com/lightblue-platform/lightblue-client/pull/59 being merged in.

This will cause the migrator to throw and subsequently log an exception if lightblue should return an error