### PR TITLE
Enable slf4j to use log4j config

### DIFF
--- a/consistency-checker/pom.xml
+++ b/consistency-checker/pom.xml
@@ -49,7 +49,7 @@
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-simple</artifactId>
+      <artifactId>slf4j-log4j12</artifactId>
     </dependency>
     <dependency>
       <groupId>commons-daemon</groupId>

--- a/consistency-checker/src/main/resources/log4j.properties
+++ b/consistency-checker/src/main/resources/log4j.properties
@@ -13,7 +13,7 @@ log4j.rootLogger=INFO, console
 log4j.appender.console=org.apache.log4j.ConsoleAppender
 log4j.appender.console.Threshold=INFO
 log4j.appender.console.layout=org.apache.log4j.PatternLayout
-log4j.appender.console.layout.ConversionPattern= %d %c %p %m%n
+log4j.appender.console.layout.ConversionPattern= %d [%t] %c %p - %m%n
 #log4j.appender.console.layout.ConversionPattern= %d %p TMS - %t [%c{1}] %m%n
 
 # CLASS-SPECIFIC LOGGING LEVELS

--- a/consistency-checker/src/test/resources/simplelogger.properties
+++ b/consistency-checker/src/test/resources/simplelogger.properties
@@ -1,1 +1,0 @@
-org.slf4j.simpleLogger.defaultLogLevel=INFO


### PR DESCRIPTION
The properties file has been there, but it wasn't being used. This changes the slf4j implementation from simple to log4j.

This will probably compile, but it is dependent on https://github.com/lightblue-platform/lightblue-client/pull/60