### PR TITLE
Fixes #84: update to have one executor process a job

### DIFF
--- a/consistency-checker/src/main/java/com/redhat/lightblue/migrator/consistency/ConsistencyChecker.java
+++ b/consistency-checker/src/main/java/com/redhat/lightblue/migrator/consistency/ConsistencyChecker.java
@@ -29,8 +29,8 @@ public class ConsistencyChecker implements Runnable{
 
     public static final Logger LOGGER = LoggerFactory.getLogger(ConsistencyChecker.class);
 
-    public static final int MAX_JOB_WAIT_TIME = 86400000; // 24 hours
-    public static final int MAX_THREAD_WAIT_TIME = 21600; // 6 hours
+    public static final int MAX_JOB_WAIT_TIME_MSEC = 24 * 60 *60 * 1000; // 24 hours
+    public static final int MAX_THREAD_WAIT_TIME_MSEC = 6 * 60 * 60 * 1000; // 6 hours
 
     private String consistencyCheckerName;
     private String hostName;
@@ -150,7 +150,7 @@ public class ConsistencyChecker implements Runnable{
                     MigrationJob nextJob = getNextAvailableJob();
                     long timeUntilNextJob = nextJob.getWhenAvailableDate().getTime() - new Date().getTime();
                     try{
-                        Thread.sleep((timeUntilNextJob > MAX_JOB_WAIT_TIME) ? MAX_JOB_WAIT_TIME : timeUntilNextJob);
+                        Thread.sleep((timeUntilNextJob > MAX_JOB_WAIT_TIME_MSEC) ? MAX_JOB_WAIT_TIME_MSEC : timeUntilNextJob);
                     }
                     catch (InterruptedException e){
                         run = false;
@@ -163,7 +163,7 @@ public class ConsistencyChecker implements Runnable{
                 if((!Thread.interrupted())){
                     try{
                         for (ExecutorService executor : executors) {
-                            executor.awaitTermination(MAX_THREAD_WAIT_TIME, TimeUnit.MILLISECONDS);
+                            executor.awaitTermination(MAX_THREAD_WAIT_TIME_MSEC, TimeUnit.MILLISECONDS);
                         }
                     }
                     catch (InterruptedException e) {
@@ -175,7 +175,7 @@ public class ConsistencyChecker implements Runnable{
     }
 
     protected List<MigrationJob> getMigrationJobs(MigrationConfiguration configuration) {
-        List<MigrationJob> jobs = new ArrayList<MigrationJob>();
+        List<MigrationJob> jobs = new ArrayList<>();
         try {
             DataFindRequest findRequest = new DataFindRequest("migrationJob", migrationJobEntityVersion);
             findRequest.where(withValue("configurationName = " + configuration.getConfigurationName()));
@@ -188,7 +188,7 @@ public class ConsistencyChecker implements Runnable{
     }
 
     protected List<MigrationConfiguration> getJobConfigurations() {
-        List<MigrationConfiguration> configurations = new ArrayList<MigrationConfiguration>();
+        List<MigrationConfiguration> configurations = new ArrayList<>();
         try {
             DataFindRequest findRequest = new DataFindRequest("migrationConfiguration", migrationConfigurationEntityVersion);
             findRequest.where(withValue("consistencyCheckerName = " + getConsistencyCheckerName()));

--- a/consistency-checker/src/main/java/com/redhat/lightblue/migrator/consistency/MigrationJobExecution.java
+++ b/consistency-checker/src/main/java/com/redhat/lightblue/migrator/consistency/MigrationJobExecution.java
@@ -4,101 +4,100 @@ import java.util.Date;
 
 public class MigrationJobExecution {
 
-	private String ownerName;
-	private String hostName;
-	private String pid;
-	
-	// actual run times for job
-	private Date actualStartDate;
-	private Date actualEndDate;
+    private String ownerName;
+    private String hostName;
+    private String pid;
 
-	// did job complete successfully?
-	private boolean completedFlag;
+    // actual run times for job
+    private Date actualStartDate;
+    private Date actualEndDate;
 
-	// summary info on what the job did
-	private int processedDocumentCount;
-	private int consistentDocumentCount;
-	private int inconsistentDocumentCount;
-	private int overwrittenDocumentCount;
-	
-	public String getOwnerName() {
-		return ownerName;
-	}
+    // did job complete successfully?
+    private boolean completedFlag = false;
 
-	public void setOwnerName(String ownerName) {
-		this.ownerName = ownerName;
-	}
+    // summary info on what the job did
+    private int processedDocumentCount = 0;
+    private int consistentDocumentCount = 0;
+    private int inconsistentDocumentCount = 0;
+    private int overwrittenDocumentCount = 0;
 
-	public String getHostName() {
-		return hostName;
-	}
+    public String getOwnerName() {
+        return ownerName;
+    }
 
-	public void setHostName(String hostName) {
-		this.hostName = hostName;
-	}
+    public void setOwnerName(String ownerName) {
+        this.ownerName = ownerName;
+    }
 
-	public String getPid() {
-		return pid;
-	}
+    public String getHostName() {
+        return hostName;
+    }
 
-	public void setPid(String pid) {
-		this.pid = pid;
-	}
-	
-	public Date getActualStartDate() {
-		return actualStartDate;
-	}
+    public void setHostName(String hostName) {
+        this.hostName = hostName;
+    }
 
-	public void setActualStartDate(Date actualStartDate) {
-		this.actualStartDate = actualStartDate;
-	}
+    public String getPid() {
+        return pid;
+    }
 
-	public Date getActualEndDate() {
-		return actualEndDate;
-	}
+    public void setPid(String pid) {
+        this.pid = pid;
+    }
 
-	public void setActualEndDate(Date actualEndDate) {
-		this.actualEndDate = actualEndDate;
-	}
+    public Date getActualStartDate() {
+        return actualStartDate;
+    }
 
-	public boolean isCompletedFlag() {
-		return completedFlag;
-	}
+    public void setActualStartDate(Date actualStartDate) {
+        this.actualStartDate = actualStartDate;
+    }
 
-	public void setCompletedFlag(boolean completedFlag) {
-		this.completedFlag = completedFlag;
-	}
+    public Date getActualEndDate() {
+        return actualEndDate;
+    }
 
-	public int getProcessedDocumentCount() {
-		return processedDocumentCount;
-	}
+    public void setActualEndDate(Date actualEndDate) {
+        this.actualEndDate = actualEndDate;
+    }
 
-	public void setProcessedDocumentCount(int processedDocumentCount) {
-		this.processedDocumentCount = processedDocumentCount;
-	}
+    public boolean isCompletedFlag() {
+        return completedFlag;
+    }
 
-	public int getConsistentDocumentCount() {
-		return consistentDocumentCount;
-	}
+    public void setCompletedFlag(boolean completedFlag) {
+        this.completedFlag = completedFlag;
+    }
 
-	public void setConsistentDocumentCount(int consistentDocumentCount) {
-		this.consistentDocumentCount = consistentDocumentCount;
-	}
+    public int getProcessedDocumentCount() {
+        return processedDocumentCount;
+    }
 
-	public int getInconsistentDocumentCount() {
-		return inconsistentDocumentCount;
-	}
+    public void setProcessedDocumentCount(int processedDocumentCount) {
+        this.processedDocumentCount = processedDocumentCount;
+    }
 
-	public void setInconsistentDocumentCount(int inconsistentDocumentCount) {
-		this.inconsistentDocumentCount = inconsistentDocumentCount;
-	}
+    public int getConsistentDocumentCount() {
+        return consistentDocumentCount;
+    }
 
-	public int getOverwrittenDocumentCount() {
-		return overwrittenDocumentCount;
-	}
+    public void setConsistentDocumentCount(int consistentDocumentCount) {
+        this.consistentDocumentCount = consistentDocumentCount;
+    }
 
-	public void setOverwrittenDocumentCount(int overwrittenDocumentCount) {
-		this.overwrittenDocumentCount = overwrittenDocumentCount;
-	}
-	
+    public int getInconsistentDocumentCount() {
+        return inconsistentDocumentCount;
+    }
+
+    public void setInconsistentDocumentCount(int inconsistentDocumentCount) {
+        this.inconsistentDocumentCount = inconsistentDocumentCount;
+    }
+
+    public int getOverwrittenDocumentCount() {
+        return overwrittenDocumentCount;
+    }
+
+    public void setOverwrittenDocumentCount(int overwrittenDocumentCount) {
+        this.overwrittenDocumentCount = overwrittenDocumentCount;
+    }
 }

--- a/consistency-checker/src/test/java/com/redhat/lightblue/migrator/consistency/MigrationJobTest.java
+++ b/consistency-checker/src/test/java/com/redhat/lightblue/migrator/consistency/MigrationJobTest.java
@@ -34,6 +34,9 @@ import com.redhat.lightblue.client.LightblueClient;
 import com.redhat.lightblue.client.http.LightblueHttpClient;
 import com.redhat.lightblue.client.request.LightblueRequest;
 import com.redhat.lightblue.client.response.LightblueResponse;
+import static com.redhat.lightblue.migrator.consistency.MigrationJob.mapper;
+import com.redhat.lightblue.util.test.FileUtil;
+import java.util.UUID;
 
 public class MigrationJobTest {
 
@@ -80,33 +83,36 @@ public class MigrationJobTest {
      * If source and destination = null, then they match.
      */
     @Test
-    public void testDocumentsConsistent_With_Source_Null_And_Destination_Null(){
+    public void testDocumentsConsistent_With_Source_Null_And_Destination_Null() {
         assertTrue(migrationJob.documentsConsistent(null, null));
     }
 
     /**
-     * If source has a value and destinationValue = null, then they do not match.
+     * If source has a value and destinationValue = null, then they do not
+     * match.
      */
     @Test
-    public void testDocumentsConsistent_With_Source_Value_And_Destination_NullValue(){
+    public void testDocumentsConsistent_With_Source_Value_And_Destination_NullValue() {
         JsonNodeFactory factory = JsonNodeFactory.withExactBigDecimals(false);
         assertFalse(migrationJob.documentsConsistent(factory.textNode("hi"), null));
     }
 
     /**
-     * If source = null and destinationValue having a value, then they do not match.
+     * If source = null and destinationValue having a value, then they do not
+     * match.
      */
     @Test
-    public void testDocumentsConsistent_With_Source_NullValue_And_Destination_Value(){
+    public void testDocumentsConsistent_With_Source_NullValue_And_Destination_Value() {
         JsonNodeFactory factory = JsonNodeFactory.withExactBigDecimals(false);
         assertFalse(migrationJob.documentsConsistent(null, factory.textNode("hi")));
     }
 
     /**
-     * If source is an object but destinationValue is not, then they do not match.
+     * If source is an object but destinationValue is not, then they do not
+     * match.
      */
     @Test
-    public void testDocumentsConsistent_With_Source_Object_And_Destination_Not_Object(){
+    public void testDocumentsConsistent_With_Source_Object_And_Destination_Not_Object() {
         JsonNodeFactory factory = JsonNodeFactory.withExactBigDecimals(false);
         assertFalse(migrationJob.documentsConsistent(factory.objectNode(), factory.textNode("hi")));
     }
@@ -115,7 +121,7 @@ public class MigrationJobTest {
      * Source has more fields than Destination, fail.
      */
     @Test
-    public void testDocumentsConsistent_With_Source_Having_More_Fields(){
+    public void testDocumentsConsistent_With_Source_Having_More_Fields() {
         JsonNodeFactory factory = JsonNodeFactory.withExactBigDecimals(false);
         ObjectNode source = factory.objectNode();
         source.put("fieldName", "fieldValue");
@@ -127,7 +133,7 @@ public class MigrationJobTest {
      */
     @Test
     @Ignore
-    public void testDocumentsConsistent_With_Destination_Having_More_Fields(){
+    public void testDocumentsConsistent_With_Destination_Having_More_Fields() {
         JsonNodeFactory factory = JsonNodeFactory.withExactBigDecimals(false);
         ObjectNode destination = factory.objectNode();
         destination.put("fieldName", "fieldValue");
@@ -138,7 +144,7 @@ public class MigrationJobTest {
      * Matching object values, pass
      */
     @Test
-    public void testDocumentsConsistent_With_Matching_Objects(){
+    public void testDocumentsConsistent_With_Matching_Objects() {
         JsonNodeFactory factory = JsonNodeFactory.withExactBigDecimals(false);
         ObjectNode source = factory.objectNode();
         source.put("fieldName", "fieldValue");
@@ -150,10 +156,11 @@ public class MigrationJobTest {
     }
 
     /**
-     * If source is an array but destinationValue is not, then they do not match.
+     * If source is an array but destinationValue is not, then they do not
+     * match.
      */
     @Test
-    public void testDocumentsConsistent_With_Source_Array_And_Destination_Not_Array(){
+    public void testDocumentsConsistent_With_Source_Array_And_Destination_Not_Array() {
         JsonNodeFactory factory = JsonNodeFactory.withExactBigDecimals(false);
         assertFalse(migrationJob.documentsConsistent(factory.arrayNode(), factory.textNode("hi")));
     }
@@ -162,7 +169,7 @@ public class MigrationJobTest {
      * Source has more elements than Destination, fail.
      */
     @Test
-    public void testDocumentsConsistent_With_Source_Having_More_Elements(){
+    public void testDocumentsConsistent_With_Source_Having_More_Elements() {
         JsonNodeFactory factory = JsonNodeFactory.withExactBigDecimals(false);
         ArrayNode source = factory.arrayNode();
         source.add(factory.textNode("hi"));
@@ -173,7 +180,7 @@ public class MigrationJobTest {
      * Matching array values, pass
      */
     @Test
-    public void testDocumentsConsistent_With_Matching_Arrays(){
+    public void testDocumentsConsistent_With_Matching_Arrays() {
         JsonNodeFactory factory = JsonNodeFactory.withExactBigDecimals(false);
         ArrayNode source = factory.arrayNode();
         source.add(factory.textNode("hi"));
@@ -188,7 +195,7 @@ public class MigrationJobTest {
      * Array values out of order, fail
      */
     @Test
-    public void testDocumentsConsistent_With_Matching_Arrays_But_OutOfSequence(){
+    public void testDocumentsConsistent_With_Matching_Arrays_But_OutOfSequence() {
         JsonNodeFactory factory = JsonNodeFactory.withExactBigDecimals(false);
         ArrayNode source = factory.arrayNode();
         source.add(factory.textNode("hi"));
@@ -205,7 +212,7 @@ public class MigrationJobTest {
      * Destination has more elements than Source, fail.
      */
     @Test
-    public void testDocumentsConsistent_With_Destination_Having_More_Elements(){
+    public void testDocumentsConsistent_With_Destination_Having_More_Elements() {
         JsonNodeFactory factory = JsonNodeFactory.withExactBigDecimals(false);
         ArrayNode destination = factory.arrayNode();
         destination.add(factory.textNode("hi"));
@@ -213,10 +220,11 @@ public class MigrationJobTest {
     }
 
     /**
-     * If source = some value and destinationValue = some other value, then consider equivalent.
+     * If source = some value and destinationValue = some other value, then
+     * consider equivalent.
      */
     @Test
-    public void testDocumentsConsistent_SourceAndDestinationNotConsistent(){
+    public void testDocumentsConsistent_SourceAndDestinationNotConsistent() {
         JsonNodeFactory factory = JsonNodeFactory.withExactBigDecimals(false);
         ObjectNode sourceNode = factory.objectNode();
         sourceNode.put("somekey", factory.textNode("faketext"));
@@ -228,11 +236,11 @@ public class MigrationJobTest {
     }
 
     /**
-     * Technically the two values do not match, however the field in question
-     * is excluded and should pass.
+     * Technically the two values do not match, however the field in question is
+     * excluded and should pass.
      */
     @Test
-    public void testDocumentsConsistent_WithMultiLevelExclude(){
+    public void testDocumentsConsistent_WithMultiLevelExclude() {
         JsonNodeFactory factory = JsonNodeFactory.withExactBigDecimals(false);
 
         ObjectNode sourceChild = factory.objectNode();
@@ -255,11 +263,11 @@ public class MigrationJobTest {
     }
 
     /**
-     * Ensures that a more complex json document, with a deep invalid field but where that field is excluded.
-     * Should pass.
+     * Ensures that a more complex json document, with a deep invalid field but
+     * where that field is excluded. Should pass.
      */
     @Test
-    public void testDocumentsConsistent_ComplexJson_Pass() throws Exception{
+    public void testDocumentsConsistent_ComplexJson_Pass() throws Exception {
         ObjectMapper mapper = new ObjectMapper();
 
         JsonNode source = mapper.readTree(
@@ -280,7 +288,7 @@ public class MigrationJobTest {
      * Should fail.
      */
     @Test
-    public void testDocumentsConsistent_ComplexJson_Fail() throws Exception{
+    public void testDocumentsConsistent_ComplexJson_Fail() throws Exception {
         ObjectMapper mapper = new ObjectMapper();
 
         JsonNode source = mapper.readTree(
@@ -293,11 +301,11 @@ public class MigrationJobTest {
     }
 
     /**
-     * Ensures that a more complex json document with a top level array, with a deep invalid field but where that field is excluded.
-     * Should pass.
+     * Ensures that a more complex json document with a top level array, with a
+     * deep invalid field but where that field is excluded. Should pass.
      */
     @Test
-    public void testDocumentsConsistent_ComplexJson_WithTopLevelArray_Pass() throws Exception{
+    public void testDocumentsConsistent_ComplexJson_WithTopLevelArray_Pass() throws Exception {
         ObjectMapper mapper = new ObjectMapper();
 
         JsonNode source = mapper.readTree(
@@ -314,11 +322,11 @@ public class MigrationJobTest {
     }
 
     /**
-     * Ensures that a more complex json document with a top level array, with a deep invalid field.
-     * Should fail.
+     * Ensures that a more complex json document with a top level array, with a
+     * deep invalid field. Should fail.
      */
     @Test
-    public void testDocumentsConsistent_ComplexJson_WithTopLevelArray_Fail() throws Exception{
+    public void testDocumentsConsistent_ComplexJson_WithTopLevelArray_Fail() throws Exception {
         ObjectMapper mapper = new ObjectMapper();
 
         JsonNode source = mapper.readTree(
@@ -335,7 +343,7 @@ public class MigrationJobTest {
      * Should fail.
      */
     @Test
-    public void testDocumentsConsistent_ComplexJson_WithTopLevelArray_ExcludeNotOnField_Fail() throws Exception{
+    public void testDocumentsConsistent_ComplexJson_WithTopLevelArray_ExcludeNotOnField_Fail() throws Exception {
         ObjectMapper mapper = new ObjectMapper();
 
         JsonNode source = mapper.readTree(
@@ -352,11 +360,11 @@ public class MigrationJobTest {
     }
 
     /**
-     * Top level something field is mismatched, but is also excluded.
-     * Should pass.
+     * Top level something field is mismatched, but is also excluded. Should
+     * pass.
      */
     @Test
-    public void testDocumentsConsistent_ComplexJson_WithTopLevelMismatch_fail() throws Exception{
+    public void testDocumentsConsistent_ComplexJson_WithTopLevelMismatch_fail() throws Exception {
         ObjectMapper mapper = new ObjectMapper();
 
         JsonNode source = mapper.readTree(
@@ -373,7 +381,7 @@ public class MigrationJobTest {
     }
 
     @Test
-    public void testGetDestinationDocuments_UnderBatchingLimit() throws IOException{
+    public void testGetDestinationDocuments_UnderBatchingLimit() throws IOException {
         String key = "id";
         String value = "uniqueId";
 
@@ -398,7 +406,7 @@ public class MigrationJobTest {
     }
 
     @Test
-    public void testGetDestinationDocuments_OverBatchingLimit_MultipleOfLimit() throws IOException{
+    public void testGetDestinationDocuments_OverBatchingLimit_MultipleOfLimit() throws IOException {
         String key = "id";
         String value = "uniqueId";
 
@@ -406,7 +414,7 @@ public class MigrationJobTest {
         migrationJob.getJobConfiguration().setDestinationIdentityFields(Arrays.asList(key));
 
         Map<String, JsonNode> sourceDocuments = new HashMap<>();
-        for(int x = 0; x < (MigrationJob.BATCH_SIZE * 2); x++){
+        for (int x = 0; x < (MigrationJob.BATCH_SIZE * 2); x++) {
             ObjectNode document = factory.objectNode();
             document.put(key, factory.textNode(value + x));
             sourceDocuments.put(value + x, document);
@@ -419,8 +427,8 @@ public class MigrationJobTest {
         dd2.put(key, value + 101);
         JsonNode[] destinationDocumentsBatch2 = new JsonNode[]{dd2};
         when(destinationClientMock.data(any(LightblueRequest.class), eq(JsonNode[].class)))
-        .thenReturn(destinationDocumentsBatch1)
-        .thenReturn(destinationDocumentsBatch2);
+                .thenReturn(destinationDocumentsBatch1)
+                .thenReturn(destinationDocumentsBatch2);
 
         Map<String, JsonNode> actual = migrationJob.getDestinationDocuments(sourceDocuments);
 
@@ -430,7 +438,7 @@ public class MigrationJobTest {
     }
 
     @Test
-    public void testGetDestinationDocuments_OverBatchingLimit() throws IOException{
+    public void testGetDestinationDocuments_OverBatchingLimit() throws IOException {
         String key = "id";
         String value = "uniqueId";
 
@@ -438,7 +446,7 @@ public class MigrationJobTest {
         migrationJob.getJobConfiguration().setDestinationIdentityFields(Arrays.asList(key));
 
         Map<String, JsonNode> sourceDocuments = new HashMap<>();
-        for(int x = 0; x < (MigrationJob.BATCH_SIZE + 1); x++){
+        for (int x = 0; x < (MigrationJob.BATCH_SIZE + 1); x++) {
             ObjectNode document = factory.objectNode();
             document.put(key, factory.textNode(value + x));
             sourceDocuments.put(value + x, document);
@@ -451,8 +459,8 @@ public class MigrationJobTest {
         dd2.put(key, value + 101);
         JsonNode[] destinationDocumentsBatch2 = new JsonNode[]{dd2};
         when(destinationClientMock.data(any(LightblueRequest.class), eq(JsonNode[].class)))
-        .thenReturn(destinationDocumentsBatch1)
-        .thenReturn(destinationDocumentsBatch2);
+                .thenReturn(destinationDocumentsBatch1)
+                .thenReturn(destinationDocumentsBatch2);
 
         Map<String, JsonNode> actual = migrationJob.getDestinationDocuments(sourceDocuments);
 
@@ -462,24 +470,24 @@ public class MigrationJobTest {
     }
 
     @Test
-    public void testGetDestinationDocuments_NullMap(){
+    public void testGetDestinationDocuments_NullMap() {
         assertTrue(migrationJob.getDestinationDocuments(null).isEmpty());
     }
 
     @Test
-    public void testGetDestinationDocuments_EmptyMap(){
+    public void testGetDestinationDocuments_EmptyMap() {
         assertTrue(migrationJob.getDestinationDocuments(new HashMap<String, JsonNode>()).isEmpty());
     }
 
     @Test
-    public void testOverwriteLightblue_OverBatchingLimit_MultipleOfLimit() throws IOException{
+    public void testOverwriteLightblue_OverBatchingLimit_MultipleOfLimit() throws IOException {
         String key = "id";
         String value = "uniqueId";
 
         JsonNodeFactory factory = JsonNodeFactory.withExactBigDecimals(false);
 
         List<JsonNode> documentsToOverwrite = new ArrayList<>();
-        for(int x = 0; x < (MigrationJob.BATCH_SIZE * 2); x++){
+        for (int x = 0; x < (MigrationJob.BATCH_SIZE * 2); x++) {
             ObjectNode document = factory.objectNode();
             document.put(key, factory.textNode(value + x));
             documentsToOverwrite.add(document);
@@ -493,14 +501,14 @@ public class MigrationJobTest {
     }
 
     @Test
-    public void testOverwriteLightblue_OverBatchingLimit() throws IOException{
+    public void testOverwriteLightblue_OverBatchingLimit() throws IOException {
         String key = "id";
         String value = "uniqueId";
 
         JsonNodeFactory factory = JsonNodeFactory.withExactBigDecimals(false);
 
         List<JsonNode> documentsToOverwrite = new ArrayList<>();
-        for(int x = 0; x < (MigrationJob.BATCH_SIZE + 1); x++){
+        for (int x = 0; x < (MigrationJob.BATCH_SIZE + 1); x++) {
             ObjectNode document = factory.objectNode();
             document.put(key, factory.textNode(value + x));
             documentsToOverwrite.add(document);
@@ -823,7 +831,6 @@ public class MigrationJobTest {
         Assert.assertEquals(0, migrationJob.getRecordsOverwritten());
     }
 
-
     @Test
     public void testExecuteSingleMultipleExistsInDestinationButNotSource() {
         MigrationJob migrationJob = new MigrationJob() {
@@ -922,4 +929,112 @@ public class MigrationJobTest {
         return actualObj;
     }
 
-}
+    /**
+     * This job is the first of two to execute and therefore should process the job.
+     * @throws Exception 
+     */
+    @Test
+    public void testMultipleJobExecutors_first() throws Exception {
+        MigrationJob migrationJob = new MigrationJob() {
+            // array of responses to return
+            private String[] jsonResponses = new String[]{
+                // initial job save
+                FileUtil.readFile("migrationJobTwoExecutionsResponse.json"),
+                // save one document
+                "{\"errors\":[],\"matchCount\":1,\"modifiedCount\":1,\"status\":\"OK\",\"processed\":[{}]}",
+                // final job save
+                FileUtil.readFile("migrationJobTwoExecutionsResponse.json")
+            };
+            
+            private int jsonResponsesPsn = 0;
+
+            @Override
+            protected LinkedHashMap<String, JsonNode> findSourceData(LightblueRequest dataRequest) {
+                return getProcessedContentsFrom("multipleFindResponseSource.json");
+            }
+
+            @Override
+            protected LinkedHashMap<String, JsonNode> findDestinationData(LightblueRequest dataRequest) {
+                return getProcessedContentsFrom("singleFindResponse.json");
+            }
+
+            @Override
+            protected LightblueResponse callLightblue(LightblueRequest saveRequest) {
+                LightblueResponse response = new LightblueResponse();
+                JsonNode node = null;
+                try {
+                    node = mapper.readTree(jsonResponses[jsonResponsesPsn++]);
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+                response.setJson(node);
+                return response;
+            }
+        };
+
+        // this job will be the first executor and therefore wins
+        migrationJob.setPid("pid1");
+
+        configureMigrationJob(migrationJob);
+        migrationJob.run();
+        Assert.assertTrue(migrationJob.hasInconsistentDocuments());
+        Assert.assertEquals(2, migrationJob.getDocumentsProcessed());
+        Assert.assertEquals(1, migrationJob.getConsistentDocuments());
+        Assert.assertEquals(1, migrationJob.getInconsistentDocuments());
+        Assert.assertEquals(1, migrationJob.getRecordsOverwritten());
+    }
+    
+    /**
+     * This job is the second to attempt to process it and therefore it should 
+     * not actually do anything.
+     * 
+     * @throws Exception 
+     */
+    @Test
+    public void testMultipleJobExecutors_second() throws Exception {
+        MigrationJob migrationJob = new MigrationJob() {
+            // array of responses to return
+            private String[] jsonResponses = new String[]{
+                // initial job save
+                FileUtil.readFile("migrationJobTwoExecutionsResponse.json"),
+                // final job save (since this is a noop, there is nothing in the middle)
+                FileUtil.readFile("migrationJobTwoExecutionsResponse.json")
+            };
+            
+            private int jsonResponsesPsn = 0;
+
+            @Override
+            protected LinkedHashMap<String, JsonNode> findSourceData(LightblueRequest dataRequest) {
+                return getProcessedContentsFrom("multipleFindResponseSource.json");
+            }
+
+            @Override
+            protected LinkedHashMap<String, JsonNode> findDestinationData(LightblueRequest dataRequest) {
+                return getProcessedContentsFrom("singleFindResponse.json");
+            }
+
+            @Override
+            protected LightblueResponse callLightblue(LightblueRequest saveRequest) {
+                LightblueResponse response = new LightblueResponse();
+                JsonNode node = null;
+                try {
+                    node = mapper.readTree(jsonResponses[jsonResponsesPsn++]);
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+                response.setJson(node);
+                return response;
+            }
+        };
+
+        // this job will be the second executor and therefore looses
+        migrationJob.setPid("pid2");
+
+        configureMigrationJob(migrationJob);
+        migrationJob.run();
+        Assert.assertFalse(migrationJob.hasInconsistentDocuments());
+        Assert.assertEquals(0, migrationJob.getDocumentsProcessed());
+        Assert.assertEquals(0, migrationJob.getConsistentDocuments());
+        Assert.assertEquals(0, migrationJob.getInconsistentDocuments());
+        Assert.assertEquals(0, migrationJob.getRecordsOverwritten());
+    }}

--- a/consistency-checker/src/test/java/com/redhat/lightblue/migrator/consistency/MigrationJobTest.java
+++ b/consistency-checker/src/test/java/com/redhat/lightblue/migrator/consistency/MigrationJobTest.java
@@ -478,7 +478,7 @@ public class MigrationJobTest {
 
         JsonNodeFactory factory = JsonNodeFactory.withExactBigDecimals(false);
 
-        List<JsonNode> documentsToOverwrite = new ArrayList<JsonNode>();
+        List<JsonNode> documentsToOverwrite = new ArrayList<>();
         for(int x = 0; x < (MigrationJob.BATCH_SIZE * 2); x++){
             ObjectNode document = factory.objectNode();
             document.put(key, factory.textNode(value + x));
@@ -499,7 +499,7 @@ public class MigrationJobTest {
 
         JsonNodeFactory factory = JsonNodeFactory.withExactBigDecimals(false);
 
-        List<JsonNode> documentsToOverwrite = new ArrayList<JsonNode>();
+        List<JsonNode> documentsToOverwrite = new ArrayList<>();
         for(int x = 0; x < (MigrationJob.BATCH_SIZE + 1); x++){
             ObjectNode document = factory.objectNode();
             document.put(key, factory.textNode(value + x));
@@ -532,7 +532,7 @@ public class MigrationJobTest {
                 ObjectMapper mapper = new ObjectMapper();
                 JsonNode node = null;
                 try {
-                    node = mapper.readTree("{\"errors\":[],\"matchCount\":0,\"modifiedCount\":0,\"status\":\"OK\"}");
+                    node = mapper.readTree("{\"errors\":[],\"matchCount\":0,\"modifiedCount\":0,\"status\":\"OK\",\"processed\":[{}]}");
                 } catch (IOException e) {
                     // TODO Auto-generated catch block
                     e.printStackTrace();
@@ -587,7 +587,7 @@ public class MigrationJobTest {
                 ObjectMapper mapper = new ObjectMapper();
                 JsonNode node = null;
                 try {
-                    node = mapper.readTree("{\"errors\":[],\"matchCount\":0,\"modifiedCount\":1,\"status\":\"OK\"}");
+                    node = mapper.readTree("{\"errors\":[],\"matchCount\":0,\"modifiedCount\":1,\"status\":\"OK\",\"processed\":[{}]}");
                 } catch (IOException e) {
                     e.printStackTrace();
                 }
@@ -623,7 +623,7 @@ public class MigrationJobTest {
                 ObjectMapper mapper = new ObjectMapper();
                 JsonNode node = null;
                 try {
-                    node = mapper.readTree("{\"errors\":[],\"matchCount\":0,\"modifiedCount\":1,\"status\":\"OK\"}");
+                    node = mapper.readTree("{\"errors\":[],\"matchCount\":0,\"modifiedCount\":1,\"status\":\"OK\",\"processed\":[{}]}");
                 } catch (IOException e) {
                     e.printStackTrace();
                 }
@@ -661,7 +661,7 @@ public class MigrationJobTest {
                 ObjectMapper mapper = new ObjectMapper();
                 JsonNode node = null;
                 try {
-                    node = mapper.readTree("{\"errors\":[],\"matchCount\":0,\"modifiedCount\":0,\"status\":\"OK\"}");
+                    node = mapper.readTree("{\"errors\":[],\"matchCount\":0,\"modifiedCount\":0,\"status\":\"OK\",\"processed\":[{}]}");
                 } catch (IOException e) {
                     e.printStackTrace();
                 }
@@ -697,7 +697,7 @@ public class MigrationJobTest {
                 ObjectMapper mapper = new ObjectMapper();
                 JsonNode node = null;
                 try {
-                    node = mapper.readTree("{\"errors\":[],\"matchCount\":0,\"modifiedCount\":0,\"status\":\"OK\"}");
+                    node = mapper.readTree("{\"errors\":[],\"matchCount\":0,\"modifiedCount\":0,\"status\":\"OK\",\"processed\":[{}]}");
                 } catch (IOException e) {
                     e.printStackTrace();
                 }
@@ -734,7 +734,7 @@ public class MigrationJobTest {
                 ObjectMapper mapper = new ObjectMapper();
                 JsonNode node = null;
                 try {
-                    node = mapper.readTree("{\"errors\":[],\"matchCount\":2,\"modifiedCount\":2,\"status\":\"OK\"}");
+                    node = mapper.readTree("{\"errors\":[],\"matchCount\":2,\"modifiedCount\":2,\"status\":\"OK\",\"processed\":[{}]}}");
                 } catch (IOException e) {
                     e.printStackTrace();
                 }
@@ -770,7 +770,7 @@ public class MigrationJobTest {
                 ObjectMapper mapper = new ObjectMapper();
                 JsonNode node = null;
                 try {
-                    node = mapper.readTree("{\"errors\":[],\"matchCount\":0,\"modifiedCount\":0,\"status\":\"OK\"}");
+                    node = mapper.readTree("{\"errors\":[],\"matchCount\":0,\"modifiedCount\":0,\"status\":\"OK\",\"processed\":[{}]}}");
                 } catch (IOException e) {
                     e.printStackTrace();
                 }
@@ -806,7 +806,7 @@ public class MigrationJobTest {
                 ObjectMapper mapper = new ObjectMapper();
                 JsonNode node = null;
                 try {
-                    node = mapper.readTree("{\"errors\":[],\"matchCount\":0,\"modifiedCount\":0,\"status\":\"OK\"}");
+                    node = mapper.readTree("{\"errors\":[],\"matchCount\":0,\"modifiedCount\":0,\"status\":\"OK\",\"processed\":[{}]}}");
                 } catch (IOException e) {
                     e.printStackTrace();
                 }
@@ -843,7 +843,7 @@ public class MigrationJobTest {
                 ObjectMapper mapper = new ObjectMapper();
                 JsonNode node = null;
                 try {
-                    node = mapper.readTree("{\"errors\":[],\"matchCount\":0,\"modifiedCount\":0,\"status\":\"OK\"}");
+                    node = mapper.readTree("{\"errors\":[],\"matchCount\":0,\"modifiedCount\":0,\"status\":\"OK\",\"processed\":[{}]}}");
                 } catch (IOException e) {
                     e.printStackTrace();
                 }
@@ -879,7 +879,7 @@ public class MigrationJobTest {
                 ObjectMapper mapper = new ObjectMapper();
                 JsonNode node = null;
                 try {
-                    node = mapper.readTree("{\"errors\":[],\"matchCount\":1,\"modifiedCount\":1,\"status\":\"OK\"}");
+                    node = mapper.readTree("{\"errors\":[],\"matchCount\":1,\"modifiedCount\":1,\"status\":\"OK\",\"processed\":[{}]}}");
                 } catch (IOException e) {
                     e.printStackTrace();
                 }
@@ -898,7 +898,7 @@ public class MigrationJobTest {
 
     private void configureMigrationJob(MigrationJob migrationJob) {
         MigrationConfiguration jobConfiguration = new MigrationConfiguration();
-        List<String> pathsToExclude = new ArrayList<String>();
+        List<String> pathsToExclude = new ArrayList<>();
         pathsToExclude.add("lastUpdateTime");
         jobConfiguration.setComparisonExclusionPaths(pathsToExclude);
         jobConfiguration.setDestinationIdentityFields(new ArrayList<String>());

--- a/consistency-checker/src/test/resources/migrationJobTwoExecutionsResponse.json
+++ b/consistency-checker/src/test/resources/migrationJobTwoExecutionsResponse.json
@@ -1,0 +1,38 @@
+{
+    "status": "COMPLETE",
+    "modifiedCount": 0,
+    "matchCount": 1,
+    "processed": [
+        {
+            "_id": "country_1332",
+            "expectedExecutionMilliseconds": 30000,
+            "createdBy": "dcrissma",
+            "lastUpdatedBy": "dcrissma",
+            "jobExecutions": [
+                {
+                    "ownerName": "migrator",
+                    "hostName": "hostname1",
+                    "pid": "pid1",
+                    "completedFlag": false,
+                    "processedDocumentCount": 0,
+                    "consistentDocumentCount": 0,
+                    "inconsistentDocumentCount": 0,
+                    "overwrittenDocumentCount": 0
+                },
+                {
+                    "ownerName": "migrator",
+                    "hostName": "hostname2",
+                    "pid": "pid2",
+                    "completedFlag": false,
+                    "processedDocumentCount": 0,
+                    "consistentDocumentCount": 0,
+                    "inconsistentDocumentCount": 0,
+                    "overwrittenDocumentCount": 0
+                }
+            ],
+            "configurationName": "country",
+            "objectType": "migrationJob",
+            "jobExecutions#": 2
+        }
+    ]
+}


### PR DESCRIPTION
If multiple migrator instances try to process a job the execution that was put in the array first wins.  All other executions are marked as complete and end date is set.  The indication that nothing was done is in the document counts.  There is no special flag or anything to indicate it didn't do any work other than those counts.