### PR TITLE
protects against 0 and negative thread values, either case will be considered a skip

### DIFF
--- a/consistency-checker/src/main/java/com/redhat/lightblue/migrator/consistency/ConsistencyChecker.java
+++ b/consistency-checker/src/main/java/com/redhat/lightblue/migrator/consistency/ConsistencyChecker.java
@@ -133,6 +133,10 @@ public class ConsistencyChecker implements Runnable {
             List<MigrationConfiguration> configurations = getJobConfigurations();
 
             for (MigrationConfiguration configuration : configurations) {
+                if (configuration.getThreadCount() < 1) {
+                    continue;
+                }
+
                 configuration.setConfigFilePath(configPath);
                 configuration.setMigrationJobEntityVersion(migrationJobEntityVersion);
                 List<MigrationJob> jobs = getMigrationJobs(configuration);


### PR DESCRIPTION
Thread count was set to 0 in job configuration entity.