### PR TITLE
Fixes unit test error

### DIFF
--- a/consistency-checker/src/test/java/com/redhat/lightblue/migrator/consistency/MigrationJobTest.java
+++ b/consistency-checker/src/test/java/com/redhat/lightblue/migrator/consistency/MigrationJobTest.java
@@ -947,7 +947,7 @@ public class MigrationJobTest {
         pathsToExclude.add("lastUpdateTime");
         jobConfiguration.setComparisonExclusionPaths(pathsToExclude);
         jobConfiguration.setDestinationIdentityFields(new ArrayList<String>());
-        jobConfiguration.setSourceTimestampPath("source-timestamp");
+        jobConfiguration.setSourceTimestampPath("sourceTimestamp");
         migrationJob.setJobConfiguration(jobConfiguration);
         migrationJob.setOverwriteDestinationDocuments(true);
         migrationJob.setJobExecutions(new ArrayList<MigrationJobExecution>());


### PR DESCRIPTION
Started having unit tests fail because source timestamp value was `source-timestamp`.  Specific error was:

```
java.lang.IllegalArgumentException: -timestamp operator is not allowed. Allowed options are: [$gte, $eq, $neq, $lt, <=, !=, $lte, >=, >, =, <]
	at com.redhat.lightblue.client.expression.query.ValueQuery.<init>(ValueQuery.java:37)
	at com.redhat.lightblue.client.expression.query.ValueQuery.withValue(ValueQuery.java:74)
	at com.redhat.lightblue.migrator.consistency.MigrationJob.getSourceDocuments(MigrationJob.java:488)
	at com.redhat.lightblue.migrator.consistency.MigrationJob.run(MigrationJob.java:286)
	at com.redhat.lightblue.migrator.consistency.MigrationJobTest.testExecuteMultipleExistsInSourceAndDestination(MigrationJobTest.java:756)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:47)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:44)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:271)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:70)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:50)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
	at org.apache.maven.surefire.junit4.JUnit4TestSet.execute(JUnit4TestSet.java:45)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:123)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:104)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.apache.maven.surefire.util.ReflectionUtils.invokeMethodWithArray(ReflectionUtils.java:164)
	at org.apache.maven.surefire.booter.ProviderFactory$ProviderProxy.invoke(ProviderFactory.java:110)
	at org.apache.maven.surefire.booter.SurefireStarter.invokeProvider(SurefireStarter.java:175)
	at org.apache.maven.surefire.booter.SurefireStarter.runSuitesInProcessWhenForked(SurefireStarter.java:107)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:68)
```