### PR TITLE
Fixes #129: changes to how executor is used

### DIFF
--- a/consistency-checker/src/test/java/com/redhat/lightblue/migrator/consistency/MigrationJobTest.java
+++ b/consistency-checker/src/test/java/com/redhat/lightblue/migrator/consistency/MigrationJobTest.java
@@ -1136,9 +1136,9 @@ public class MigrationJobTest {
                 }
 
                 @Override
-                protected Map<String, JsonNode> getSourceDocuments() {
+                protected Map<String, JsonNode> getSourceDocuments() throws SQLException {
                     outstandingThreadCount.getAndDecrement();
-                    throw new RuntimeException("forced failure for testing", new SQLException("foo"));
+                    throw new SQLException("forced failure for testing");
                 }
             };
 
@@ -1151,7 +1151,7 @@ public class MigrationJobTest {
 
         // all jobs are created.  There are JOB_COUNT of them but only THREAD_COUNT threads
         // but we want to be sure to have *some* jobs to run before we wait for termination
-        Assert.assertTrue(outstandingThreadCount.intValue() > (JOB_COUNT / 2));
+        Assert.assertTrue(outstandingThreadCount.intValue() > (JOB_COUNT / 5));
         for (Future future : futures) {
             try {
                 future.get();
@@ -1202,9 +1202,9 @@ public class MigrationJobTest {
                 }
 
                 @Override
-                protected Map<String, JsonNode> getSourceDocuments() {
+                protected Map<String, JsonNode> getSourceDocuments() throws SQLException {
                     outstandingThreadCount.getAndDecrement();
-                    throw new RuntimeException("forced failure for testing", new SQLException("foo"));
+                    throw new SQLException("forced failure for testing");
                 }
             };
 


### PR DESCRIPTION
A few changes:
* throwing checked exceptions where possible (aka stop catch/wrap/throw pattern where possible)
* added unit tests to try to reproduce #129 but they don't
* changed ConsistencyChecker to use ExecutorService#submit (instead of ExecutorService#execute)