### PR TITLE
Fixes #150: Fix processing expired jobs

### DIFF
--- a/consistency-checker/src/main/java/com/redhat/lightblue/migrator/consistency/ConsistencyChecker.java
+++ b/consistency-checker/src/main/java/com/redhat/lightblue/migrator/consistency/ConsistencyChecker.java
@@ -246,17 +246,7 @@ public class ConsistencyChecker implements Runnable {
 
             LOGGER.debug("Finding Jobs to execute: {}", findRequest.getBody());
 
-            MigrationJob[] rawJobResponse = client.data(findRequest, MigrationJob[].class);
-
-            // loop through jobs to check if job can be executed
-            for (MigrationJob job : rawJobResponse) {
-                if (isJobExecutable(job)) {
-                    // mark old expirations as dead
-                    markRunningJobExecutionsAsDead(job);
-                    // add to list of jobs to process
-                    jobs.add(job);
-                }
-            }
+            jobs = Arrays.asList(client.data(findRequest, MigrationJob[].class));
         } catch (IOException e) {
             LOGGER.error("Problem getting migrationJobs", e);
         }

--- a/consistency-checker/src/main/java/com/redhat/lightblue/migrator/consistency/ConsistencyChecker.java
+++ b/consistency-checker/src/main/java/com/redhat/lightblue/migrator/consistency/ConsistencyChecker.java
@@ -227,8 +227,9 @@ public class ConsistencyChecker implements Runnable {
 
             // loop through jobs to check if job can be executed
             for (MigrationJob job : rawJobResponse) {
-                // note, isJobExecutable cleans up old execution status / end date!
                 if (isJobExecutable(job)) {
+                    // mark old expirations as dead
+                    markRunningJobExecutionsAsDead(job);
                     // add to list of jobs to process
                     jobs.add(job);
                 }
@@ -280,6 +281,7 @@ public class ConsistencyChecker implements Runnable {
         int psn = 0;
         for (MigrationJobExecution exec : job.getJobExecutions()) {
             if (exec.getJobStatus() != null && exec.getJobStatus().isRunning()) {
+                LOGGER.info("Marking job {} execution {} as {}", job.get_id(), psn, JobStatus.COMPLETED_DEAD);
                 exec.setJobStatus(JobStatus.COMPLETED_DEAD);
                 exec.setActualEndDate(new Date());
                 job.markExecutionStatusAndEndDate(psn, JobStatus.COMPLETED_DEAD, true);

--- a/consistency-checker/src/main/java/com/redhat/lightblue/migrator/consistency/ConsistencyChecker.java
+++ b/consistency-checker/src/main/java/com/redhat/lightblue/migrator/consistency/ConsistencyChecker.java
@@ -246,7 +246,7 @@ public class ConsistencyChecker implements Runnable {
 
             LOGGER.debug("Finding Jobs to execute: {}", findRequest.getBody());
 
-            jobs = Arrays.asList(client.data(findRequest, MigrationJob[].class));
+            jobs.addAll(Arrays.asList(client.data(findRequest, MigrationJob[].class)));
         } catch (IOException e) {
             LOGGER.error("Problem getting migrationJobs", e);
         }

--- a/consistency-checker/src/main/java/com/redhat/lightblue/migrator/consistency/ConsistencyChecker.java
+++ b/consistency-checker/src/main/java/com/redhat/lightblue/migrator/consistency/ConsistencyChecker.java
@@ -277,7 +277,7 @@ public class ConsistencyChecker implements Runnable {
      *
      * @param job the job to cleanup
      */
-    protected static void markRunningJobExecutionsAsDead(MigrationJob job) {
+    protected static void markRunningJobExecutionsAsDead(MigrationJob job) throws IOException {
         int psn = 0;
         for (MigrationJobExecution exec : job.getJobExecutions()) {
             if (exec.getJobStatus() != null && exec.getJobStatus().isRunning()) {


### PR DESCRIPTION
Migrator now marks executions as dead and picks them for processing again when necessary.