### PR TITLE
Sort by whenAvailableDate ascending to pick older jobs first

### DIFF
--- a/consistency-checker/src/main/java/com/redhat/lightblue/migrator/consistency/ConsistencyChecker.java
+++ b/consistency-checker/src/main/java/com/redhat/lightblue/migrator/consistency/ConsistencyChecker.java
@@ -241,9 +241,12 @@ public class ConsistencyChecker implements Runnable {
             );
             findRequest.select(includeFieldRecursively("*"));
 
+            // sort by whenAvailableDate ascending to process oldest jobs first
+            findRequest.sort(new SortCondition("whenAvailableDate", SortDirection.ASCENDING));
+
             // only pick up the first MAX_JOBS_PER_ENTITY jobs
             findRequest.range(0, MAX_JOBS_PER_ENTITY);
-
+            
             LOGGER.debug("Finding Jobs to execute: {}", findRequest.getBody());
 
             jobs.addAll(Arrays.asList(client.data(findRequest, MigrationJob[].class)));


### PR DESCRIPTION
Noticed in a dev migration that we didn't pick older jobs consistently.  Basically, we had to stop migration several times which leaves jobs in a "RUNNING" state.  We expected them to be picked up and reprocessed after those executions marked as dead.  This didn't happen until all other jobs had been migrated.  This fixes the issue and sorts when getting migrationJob documents to process.