### PR TITLE
Fixes #162: Fix get next available job

### DIFF
--- a/consistency-checker/pom.xml
+++ b/consistency-checker/pom.xml
@@ -66,7 +66,7 @@
     </dependency>
     <dependency>
       <groupId>com.redhat.lightblue</groupId>
-      <artifactId>util</artifactId>
+      <artifactId>lightblue-core-util</artifactId>
       <scope>test</scope>
     </dependency>
    <dependency>

--- a/consistency-checker/src/main/java/com/redhat/lightblue/migrator/consistency/ConsistencyChecker.java
+++ b/consistency-checker/src/main/java/com/redhat/lightblue/migrator/consistency/ConsistencyChecker.java
@@ -331,7 +331,10 @@ public class ConsistencyChecker implements Runnable {
             findRequest.select(includeFieldRecursively("*"));
 
             LOGGER.debug("Get next job: {}", findRequest.getBody());
-            job = client.data(findRequest, MigrationJob.class);
+            MigrationJob[] jobs = client.data(findRequest, MigrationJob[].class);
+            if (jobs != null && jobs.length > 0) {
+                job = jobs[0];
+            }
         } catch (IOException e) {
             LOGGER.error("Problem getting migrationJob", e);
         }

--- a/consistency-checker/src/test/java/com/redhat/lightblue/migrator/consistency/ConsistencyCheckerTest.java
+++ b/consistency-checker/src/test/java/com/redhat/lightblue/migrator/consistency/ConsistencyCheckerTest.java
@@ -13,6 +13,9 @@ import org.slf4j.LoggerFactory;
 
 import com.redhat.lightblue.client.LightblueClient;
 import com.redhat.lightblue.client.http.LightblueHttpClient;
+import com.redhat.lightblue.client.request.LightblueRequest;
+import com.redhat.lightblue.client.response.LightblueResponse;
+import java.io.IOException;
 
 public class ConsistencyCheckerTest {
 
@@ -157,7 +160,7 @@ public class ConsistencyCheckerTest {
         checker.run();
 
     }
-
+    
     @Test
     public void isJobExecutable_NoExecutions() {
         MigrationJob job = new MigrationJob();
@@ -191,4 +194,33 @@ public class ConsistencyCheckerTest {
         Assert.assertFalse(ConsistencyChecker.isJobExecutable(job));
     }
 
+    @Test
+    public void getNextAvailableJob() {
+        final String pid = "jewzaam was here";
+        
+        checker.setClient(new LightblueClient() {
+            @Override
+            public LightblueResponse metadata(LightblueRequest lr) {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public LightblueResponse data(LightblueRequest lr) {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public <T> T data(LightblueRequest lr, Class<T> type) throws IOException {
+                MigrationJob[] jobs = new MigrationJob[1];
+                jobs[0] = new MigrationJob();
+                jobs[0].setPid(pid);
+                return (T)jobs;
+            }
+        });
+        
+        MigrationJob job = checker.getNextAvailableJob();
+        
+        Assert.assertNotNull(job);
+        Assert.assertEquals(pid, job.getPid());
+    }
 }

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -9,7 +9,6 @@
   <groupId>com.redhat.lightblue.migrator</groupId>
   <artifactId>lightblue-migrator-core</artifactId>
   <packaging>jar</packaging>
-  <version>0.0.1-SNAPSHOT</version>
   <name>lightblue-migrator: ${project.groupId}|${project.artifactId}</name>
   <dependencies>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -144,8 +144,8 @@
         </dependency>
         <dependency>
             <groupId>com.redhat.lightblue</groupId>
-            <artifactId>util</artifactId>
-            <version>1.3.0-SNAPSHOT</version>
+            <artifactId>lightblue-core-util</artifactId>
+            <version>1.4.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.redhat.lightblue.client</groupId>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -9,7 +9,6 @@
   <groupId>com.redhat.lightblue.migrator</groupId>
   <artifactId>lightblue-migrator-test</artifactId>
   <packaging>jar</packaging>
-  <version>0.0.1-SNAPSHOT</version>
   <name>lightblue-migrator: ${project.groupId}|${project.artifactId}</name>
   <dependencies>
     <dependency>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -9,7 +9,6 @@
   <groupId>com.redhat.lightblue.migrator</groupId>
   <artifactId>lightblue-migrator-utils</artifactId>
   <packaging>jar</packaging>
-  <version>0.0.1-SNAPSHOT</version>
   <name>lightblue-migrator: ${project.groupId}|${project.artifactId}</name>
   <dependencies>
     <dependency>
@@ -36,7 +35,7 @@
     <dependency>
       <groupId>com.redhat.lightblue.migrator</groupId>
       <artifactId>lightblue-migrator-core</artifactId>
-      <version>0.0.1-SNAPSHOT</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>net.sf.ehcache</groupId>
@@ -53,7 +52,7 @@
     <dependency>
       <groupId>com.redhat.lightblue.migrator</groupId>
       <artifactId>lightblue-migrator-test</artifactId>
-      <version>0.0.1-SNAPSHOT</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -9,7 +9,6 @@
   <groupId>com.redhat.lightblue.migrator</groupId>
   <artifactId>lightblue-migrator-web</artifactId>
   <packaging>war</packaging>
-  <version>0.0.1-SNAPSHOT</version>
   <name>lightblue-migrator: ${project.groupId}|${project.artifactId}</name>
   <dependencies>
     <dependency>


### PR DESCRIPTION
Also includes version fixes.  Noticed while fixing the issue so rolled it in since the issue needs fixed.

I have deployed the fix to our dev nodes and it works.  Just saw this, which is neat given it means it will sleep til 8PM, which is when the next job is ready.

```
2015-04-09 19:35:08,366 [ConsistencyCheckerRunner] INFO  [com.redhat.lightblue.migrator.consistency.ConsistencyChecker] Waiting for next job, sleeping for 1551634 msec
```