### PR TITLE
Add audit hooks to migration metadata

### DIFF
--- a/consistency-checker/src/main/resources/migrationConfiguration.json
+++ b/consistency-checker/src/main/resources/migrationConfiguration.json
@@ -6,6 +6,20 @@
             "datasource": "mongodata"
         },
         "enums": [],
+        "hooks": [
+            {
+                "actions": [
+                    "insert",
+                    "update",
+                    "delete"
+                ],
+                "configuration": {
+                    "entityName": "audit",
+                    "version": "1.0.0"
+                },
+                "name": "auditHook"
+            }
+        ],
         "indexes": [
             {
                 "fields": [

--- a/consistency-checker/src/main/resources/migrationJob.json
+++ b/consistency-checker/src/main/resources/migrationJob.json
@@ -5,6 +5,20 @@
             "collection": "migrationJob",
             "datasource": "mongodata"
         },
+        "hooks": [
+            {
+                "actions": [
+                    "insert",
+                    "update",
+                    "delete"
+                ],
+                "configuration": {
+                    "entityName": "audit",
+                    "version": "1.0.0"
+                },
+                "name": "auditHook"
+            }
+        ],
         "enums": [
             {
                 "name": "jobStatusType",

--- a/consistency-checker/src/test/java/com/redhat/lightblue/migrator/consistency/AbstractMigratorController.java
+++ b/consistency-checker/src/test/java/com/redhat/lightblue/migrator/consistency/AbstractMigratorController.java
@@ -38,6 +38,16 @@ public abstract class AbstractMigratorController extends AbstractCRUDControllerW
     }
 
     /**
+     * Temporary method that will remove the hooks from  metadata. Ideally, this
+     * method will go away once the test generic metadata supports arbitrary configurations.
+     */
+    protected ObjectNode removeHooks(ObjectNode node) {
+        ObjectNode schema = (ObjectNode) node.get("entityInfo");
+        schema.remove("hooks");
+        return node;
+    }
+
+    /**
      *
      * @param node
      * @return the schema version for the passed in node.

--- a/consistency-checker/src/test/java/com/redhat/lightblue/migrator/consistency/ITCaseConsistencyCheckerTest.java
+++ b/consistency-checker/src/test/java/com/redhat/lightblue/migrator/consistency/ITCaseConsistencyCheckerTest.java
@@ -43,8 +43,8 @@ public class ITCaseConsistencyCheckerTest extends AbstractMigratorController {
         versionMigrationConfiguration = parseEntityVersion(jsonMigrationConfiguration);
 
         return new JsonNode[]{
-                grantAnyoneAccess(jsonMigrationJob),
-                grantAnyoneAccess(jsonMigrationConfiguration)
+                removeHooks(grantAnyoneAccess(jsonMigrationJob)),
+                removeHooks(grantAnyoneAccess(jsonMigrationConfiguration))
         };
     }
 


### PR DESCRIPTION
Also required a hacky fix to tests, I created https://github.com/lightblue-platform/lightblue-mongo/issues/102 to hopefully fix down the road.