### PR TITLE
remove hook from migrationJob, makes too much noise

### DIFF
--- a/consistency-checker/src/main/resources/migrationJob.json
+++ b/consistency-checker/src/main/resources/migrationJob.json
@@ -5,20 +5,6 @@
             "collection": "migrationJob",
             "datasource": "mongodata"
         },
-        "hooks": [
-            {
-                "actions": [
-                    "insert",
-                    "update",
-                    "delete"
-                ],
-                "configuration": {
-                    "entityName": "audit",
-                    "version": "1.0.0"
-                },
-                "name": "auditHook"
-            }
-        ],
         "enums": [
             {
                 "name": "jobStatusType",


### PR DESCRIPTION
The audit hook for the migrationJob entity makes way too much unnecessary noise. Removing it.