### PR TITLE
split the init of source/dest client logic

### DIFF
--- a/consistency-checker/src/main/java/com/redhat/lightblue/migrator/consistency/MigrationJob.java
+++ b/consistency-checker/src/main/java/com/redhat/lightblue/migrator/consistency/MigrationJob.java
@@ -437,29 +437,35 @@ public class MigrationJob implements Runnable {
     private void configureClients() throws IOException {
         if (null == sourceClient || null == destinationClient) {
             synchronized (this) {
-                if (null == sourceClient || null == destinationClient) {
+                if (null == sourceClient) {
                     LightblueHttpClient source;
-                    LightblueHttpClient destination;
+
                     if (getSourceConfigPath() == null && getDestinationConfigPath() == null) {
                         source = new LightblueHttpClient();
-                        destination = new LightblueHttpClient();
                     } else {
-                        // load from config files
                         try (InputStream is = Thread.currentThread()
                                 .getContextClassLoader().getResourceAsStream(getSourceConfigPath())) {
                             LightblueClientConfiguration config = PropertiesLightblueClientConfiguration.fromInputStream(is);
                             source = new LightblueHttpClient(config);
                         }
+                    }
 
+                    sourceClient = new LightblueHystrixClient(source, "migrator", "sourceClient");
+                }
+                if (null == destinationClient) {
+                    LightblueHttpClient destination;
+
+                    if (getDestinationConfigPath() == null) {
+                        destination = new LightblueHttpClient();
+                    } else {
                         try (InputStream is = Thread.currentThread()
                                 .getContextClassLoader().getResourceAsStream(getDestinationConfigPath())) {
                             LightblueClientConfiguration config = PropertiesLightblueClientConfiguration.fromInputStream(is);
                             destination = new LightblueHttpClient(config);
                         }
                     }
-                    sourceClient = new LightblueHystrixClient(source, "migrator", "sourceClient");
-                    destinationClient = new LightblueHystrixClient(destination, "migrator", "destinationClient");
 
+                    destinationClient = new LightblueHystrixClient(destination, "migrator", "destinationClient");
                 }
             }
         }


### PR DESCRIPTION
It is possible that a source config could be provided without dest or vice-versa.