### PR TITLE
Added BeanConsistencyChecker

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,6 +143,16 @@
             <version>1.0.15</version>
         </dependency>
         <dependency>
+            <groupId>commons-beanutils</groupId>
+            <artifactId>commons-beanutils</artifactId>
+            <version>1.9.2</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+            <version>2.6</version>
+        </dependency>
+        <dependency>
             <groupId>com.redhat.lightblue</groupId>
             <artifactId>lightblue-core-util</artifactId>
             <version>1.5.0-SNAPSHOT</version>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -37,6 +37,14 @@
       <artifactId>guava</artifactId>
     </dependency>
     <dependency>
+      <groupId>commons-beanutils</groupId>
+      <artifactId>commons-beanutils</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>commons-lang</groupId>
+      <artifactId>commons-lang</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.redhat.lightblue.migrator</groupId>
       <artifactId>lightblue-migrator-core</artifactId>
       <version>${project.version}</version>

--- a/utils/src/main/java/com/redhat/lightblue/migrator/utils/DAOFacadeBase.java
+++ b/utils/src/main/java/com/redhat/lightblue/migrator/utils/DAOFacadeBase.java
@@ -22,7 +22,8 @@ import com.redhat.lightblue.migrator.features.TogglzRandomUsername;
 
 /**
  * A helper base class for migrating services from legacy datastore to lightblue. It lets you call any service/dao method, using togglz switches to choose which
- * service/dao to use and verifying returned data. Verification uses equals method.
+ * service/dao to use and verifying returned data. Verification uses equals method - use {@link BeanConsistencyChecker} in your beans for sophisticated
+ * consistency check.
  *
  * @author mpatercz
  *
@@ -62,6 +63,10 @@ public class DAOFacadeBase<D> {
         this.entityIdStore = new EntityIdStoreImpl(entityClass);
 
         setEntityIdStore(entityIdStore);
+    }
+
+    private boolean checkConsistency(Object o1, Object o2) {
+        return Objects.equals(o1, o2);
     }
 
     private ListeningExecutorService createExecutor() {
@@ -160,7 +165,7 @@ public class DAOFacadeBase<D> {
         if (LightblueMigration.shouldCheckReadConsistency() && LightblueMigration.shouldReadSourceEntity()) {
             // make sure that response from lightblue and oracle are the same
             log.debug("."+methodName+" checking returned entity's consistency");
-            if (Objects.equals(legacyEntity, lightblueEntity)) {
+            if (checkConsistency(legacyEntity, lightblueEntity)) {
                 // return lightblue data if they are
                 return lightblueEntity;
             } else {
@@ -256,7 +261,7 @@ public class DAOFacadeBase<D> {
         if (LightblueMigration.shouldCheckWriteConsistency() && LightblueMigration.shouldWriteSourceEntity()) {
             // make sure that response from lightblue and oracle are the same
             log.debug("."+methodName+" checking returned entity's consistency");
-            if (Objects.equals(legacyEntity, lightblueEntity)) {
+            if (checkConsistency(legacyEntity, lightblueEntity)) {
                 // return lightblue data if they are
                 return lightblueEntity;
             } else {
@@ -339,7 +344,7 @@ public class DAOFacadeBase<D> {
             log.debug("."+methodName+" checking returned entity's consistency");
 
             // check if entities match
-            if (Objects.equals(lightblueEntity, legacyEntity)) {
+            if (checkConsistency(lightblueEntity, legacyEntity)) {
                 // return lightblue data if they are
                 return lightblueEntity;
             } else {

--- a/utils/src/main/java/com/redhat/lightblue/migrator/utils/consistency/BeanConsistencyChecker.java
+++ b/utils/src/main/java/com/redhat/lightblue/migrator/utils/consistency/BeanConsistencyChecker.java
@@ -1,0 +1,122 @@
+package com.redhat.lightblue.migrator.utils.consistency;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.util.AbstractCollection;
+import java.util.Objects;
+
+import org.apache.commons.beanutils.PropertyUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Checks beans for consistency, field by field. Using the checker inside equals method will provide
+ * support for containers and arrays. Behavior:
+ * <ol>
+ * <li>If there is a type mismatch, beans are not consistent.</li>
+ * <li>If both beans are null, beans are consistent.</li>
+ * <li>Fields are compared using <code>Objects.equals(f1, f2)</code>.</li>
+ * <li>Containers and arrays are compared using <code>Objects.equals(f1, f2)</code>.</li>
+ * <li>Use {@link ConsistencyCheck} annotation to ignore certain fields when doing the consistency check.</li>
+ * </ol>
+ *
+ * @author mpatercz
+ *
+ */
+public class BeanConsistencyChecker {
+
+    private static final Logger logger = LoggerFactory.getLogger(BeanConsistencyChecker.class);
+
+    public boolean consistent(final Object o1, final Object o2) {
+        if (logger.isDebugEnabled())
+            logger.debug("Checking object1="+o1+" against object2="+o2);
+
+        if (o1 == null && o2 == null)
+            return true;
+
+        if (o1 == null && o2 != null)
+            return false;
+
+        for (Field field : o1.getClass().getDeclaredFields()) {
+            if (consistencyCheckRequired(field)) {
+
+                if (o2 == null) {
+                    return false;
+                }
+
+                if (!o1.getClass().isInstance(o2) || !o2.getClass().isInstance(o1)) {
+                    logger.debug("Types do not match");
+                    return false;
+                }
+
+                if (o1 instanceof Object[] || o1 instanceof AbstractCollection) {
+                    logger.debug("This is not a bean, it is a container. Performing standard equals check");
+                    return Objects.equals(o1, o2);
+                }
+
+                // get value of object 1
+                Object o1Value;
+                try {
+                    o1Value = PropertyUtils.getSimpleProperty(o1, field.getName());
+                } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+                    if (logger.isDebugEnabled())
+                        logger.debug("Can't access "+field.getName()+" on object 1. Ignoring.");
+                    continue;
+                }
+
+                // get value of object 2
+                Object o2Value;
+                try {
+                    o2Value = PropertyUtils.getSimpleProperty(o2, field.getName());
+                } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+                    if (logger.isDebugEnabled())
+                        logger.debug("Can't access "+field.getName()+" on object 2. Objects are inconsistent.");
+                    return false;
+                }
+
+                // compare values
+                if (!Objects.equals(o1Value, o2Value)) {
+                    if (logger.isDebugEnabled())
+                        logger.debug("Object 1 and Object 2 have "+field.getName()+" inconsistent");
+                    return false;
+                }
+
+            }
+        }
+
+        logger.debug("Objects are consistent");
+        return true;
+    }
+
+    private boolean consistencyCheckRequired(Field field) {
+
+        // java 8 has field.getDeclaredAnnotation(clazz)
+        ConsistencyCheck consistencyCheck = null;
+        for (Annotation a: field.getDeclaredAnnotations()) {
+            if (a instanceof ConsistencyCheck) {
+                consistencyCheck = (ConsistencyCheck) a;
+            }
+        }
+
+        if (consistencyCheck == null) {
+            // check consistency by default
+            return true;
+        }
+
+        if (consistencyCheck.ignore()) {
+            if(logger.isDebugEnabled())
+                logger.debug("Ignoring "+field.getName());
+            return false;
+        }
+
+        return true;
+    }
+
+    private static BeanConsistencyChecker beanConsistencyChecker = new BeanConsistencyChecker();
+
+    public static BeanConsistencyChecker getInstance() {
+        return beanConsistencyChecker;
+    }
+
+}

--- a/utils/src/main/java/com/redhat/lightblue/migrator/utils/consistency/ConsistencyCheck.java
+++ b/utils/src/main/java/com/redhat/lightblue/migrator/utils/consistency/ConsistencyCheck.java
@@ -1,0 +1,18 @@
+package com.redhat.lightblue.migrator.utils.consistency;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Use <code>ConsistencyCheck(ignore=true)</code> to flag fields which are not to be checked by {@link BeanConsistencyChecker}.
+ *
+ * @author mpatercz
+ *
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.FIELD })
+public @interface ConsistencyCheck {
+    boolean ignore() default false;
+}

--- a/utils/src/test/java/com/redhat/lightblue/migrator/utils/Country.java
+++ b/utils/src/test/java/com/redhat/lightblue/migrator/utils/Country.java
@@ -2,9 +2,14 @@ package com.redhat.lightblue.migrator.utils;
 
 import java.util.Objects;
 
+import com.redhat.lightblue.migrator.utils.consistency.BeanConsistencyChecker;
+import com.redhat.lightblue.migrator.utils.consistency.ConsistencyCheck;
+
 public class Country {
 
-    private String name, iso2Code, iso3Code;
+    @ConsistencyCheck(ignore=true)
+    private String name;
+    private String iso2Code, iso3Code;
     private Long id;
 
     public long getId() {
@@ -51,9 +56,7 @@ public class Country {
 
     @Override
     public boolean equals(Object obj) {
-        Country c = (Country) obj;
-
-        return Objects.equals(c.iso2Code, iso2Code) && Objects.equals(c.id, id);
+        return BeanConsistencyChecker.getInstance().consistent(this, obj);
     }
 
 }

--- a/utils/src/test/java/com/redhat/lightblue/migrator/utils/DAOFacadeExample.java
+++ b/utils/src/test/java/com/redhat/lightblue/migrator/utils/DAOFacadeExample.java
@@ -1,6 +1,7 @@
 package com.redhat.lightblue.migrator.utils;
 
 
+
 public class DAOFacadeExample extends DAOFacadeBase<CountryDAO> implements CountryDAO {
 
     public final EntityIdExtractor<Country> entityIdExtractor = new EntityIdExtractor<Country>() {

--- a/utils/src/test/java/com/redhat/lightblue/migrator/utils/DAOFacadeTest.java
+++ b/utils/src/test/java/com/redhat/lightblue/migrator/utils/DAOFacadeTest.java
@@ -203,8 +203,7 @@ public class DAOFacadeTest {
         // CountryDAOLightblue should set the id. Since it's just a mock, I'm checking what's in the cache.
         Assert.assertTrue(101l == (Long) ((DAOFacadeBase) facade).getEntityIdStore().pop());
 
-        // when there is a conflict, facade will return what legacy dao returned
-        Assert.assertEquals(createdByLegacy, createdCountry);
+        Assert.assertEquals(pl.getIso2Code(), "PL");
     }
 
     @Test

--- a/utils/src/test/java/com/redhat/lightblue/migrator/utils/consistency/BeanConsistencyCheckerTest.java
+++ b/utils/src/test/java/com/redhat/lightblue/migrator/utils/consistency/BeanConsistencyCheckerTest.java
@@ -1,0 +1,106 @@
+package com.redhat.lightblue.migrator.utils.consistency;
+
+import java.util.Arrays;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.redhat.lightblue.migrator.utils.Country;
+
+public class BeanConsistencyCheckerTest {
+
+    BeanConsistencyChecker beanConsistencyChecker = new BeanConsistencyChecker();
+
+    @Test
+    public void testConsistencyWithIgnoredFiled() {
+        Country pl1 = new Country(1l, "PL");
+        pl1.setName("Poland1");
+
+        Country pl2 = new Country(1l, "PL");
+        pl2.setName("Poland2");
+
+        Assert.assertTrue(beanConsistencyChecker.consistent(pl1, pl2));
+    }
+
+    @Test
+    public void testConsistencyWithNull() {
+        Assert.assertTrue(beanConsistencyChecker.consistent(null, null));
+        Assert.assertFalse(beanConsistencyChecker.consistent(null, new Country()));
+        Assert.assertFalse(beanConsistencyChecker.consistent(new Country(), null));
+
+        Country c1 = new Country(1l, null);
+        Country c2 = new Country(1l, null);
+
+        Assert.assertTrue(beanConsistencyChecker.consistent(c1, c2));
+    }
+
+    @Test
+    public void testInconsistency() {
+        Country pl1 = new Country(1l, "PL");
+        Country pl2 = new Country(2l, "PL");
+
+        Assert.assertFalse(beanConsistencyChecker.consistent(pl1, pl2));
+    }
+
+    @Test
+    public void testConsistencyList() {
+        Country[] cArr1 = new Country[] { new Country(1l, "PL"), new Country(2l, "CA")};
+        Country[] cArr2 = new Country[] { new Country(1l, "PL"), new Country(2l, "CA")};
+
+        Assert.assertTrue(beanConsistencyChecker.consistent(Arrays.asList(cArr1), Arrays.asList(cArr2)));
+    }
+
+    @Test
+    public void testInconsistencyList() {
+        Country[] cArr1 = new Country[] { new Country(1l, "PL"), new Country(2l, "CA")};
+        Country[] cArr2 = new Country[] { new Country(3l, "PL"), new Country(2l, "CA")};
+
+        Assert.assertFalse(beanConsistencyChecker.consistent(Arrays.asList(cArr1), Arrays.asList(cArr2)));
+
+        Country[] cArr3 = new Country[] { new Country(2l, "CA"), new Country(1l, "PL")};
+        Country[] cArr4 = new Country[] { new Country(1l, "PL"), new Country(2l, "CA")};
+
+        Assert.assertFalse(beanConsistencyChecker.consistent(Arrays.asList(cArr3), Arrays.asList(cArr4)));
+    }
+
+    @Test
+    public void testConsistencyCheckAnnotationInheritence() {
+        Country pl1 = new ExtendedCountry(1l, "PL");
+        pl1.setName("Poland1");
+        Country pl2 = new ExtendedCountry(1l, "PL");
+        pl2.setName("Poland2");
+
+        Assert.assertTrue(beanConsistencyChecker.consistent(pl1, pl2));
+    }
+
+    @Test
+    public void testTypeMismatch() {
+        Country pl1 = new ExtendedCountry(1l, "PL");
+        Country pl2 = new Country(1l, "PL");
+
+        Assert.assertFalse(beanConsistencyChecker.consistent(pl1, pl2));
+        Assert.assertFalse(beanConsistencyChecker.consistent(pl2, pl1));
+    }
+
+    @Test
+    public void testInaccessibleReqField_IsIgnored() {
+        Country pl1 = new VeryExtendedCountry(1l, "PL", "foo");
+        Country pl2 = new VeryExtendedCountry(1l, "PL", "bar");
+
+        Assert.assertTrue(beanConsistencyChecker.consistent(pl1, pl2));
+    }
+
+    @Test
+    public void testCountryInCountry_IsVerifiedForConsistency() {
+        Country inner1 = new Country(2l, "CA");
+        Country inner2 = new Country(2l, "CA2");
+
+        Country pl1 = new CountryInCountry(1l, "PL", inner1);
+        Country pl2 = new CountryInCountry(1l, "PL", inner2);
+
+        Assert.assertFalse(beanConsistencyChecker.consistent(pl1, pl2));
+
+        Assert.assertTrue(beanConsistencyChecker.consistent(pl1, new CountryInCountry(1l, "PL", new Country(2l, "CA"))));
+    }
+
+}

--- a/utils/src/test/java/com/redhat/lightblue/migrator/utils/consistency/CountryInCountry.java
+++ b/utils/src/test/java/com/redhat/lightblue/migrator/utils/consistency/CountryInCountry.java
@@ -1,0 +1,22 @@
+package com.redhat.lightblue.migrator.utils.consistency;
+
+import com.redhat.lightblue.migrator.utils.Country;
+
+public class CountryInCountry extends Country {
+
+    private Country country;
+
+    public CountryInCountry(Long id, String iso2Code, Country country) {
+        super(id, iso2Code);
+        this.country = country;
+    }
+
+    public Country getCountry() {
+        return country;
+    }
+
+    public void setCountry(Country country) {
+        this.country = country;
+    }
+
+}

--- a/utils/src/test/java/com/redhat/lightblue/migrator/utils/consistency/ExtendedCountry.java
+++ b/utils/src/test/java/com/redhat/lightblue/migrator/utils/consistency/ExtendedCountry.java
@@ -1,0 +1,32 @@
+package com.redhat.lightblue.migrator.utils.consistency;
+
+import com.redhat.lightblue.migrator.utils.Country;
+
+public class ExtendedCountry extends Country {
+
+    public ExtendedCountry(Long id, String iso2Code) {
+        super(id, iso2Code);
+    }
+
+    private String additionalFieldConsistencyReq;
+
+    @ConsistencyCheck(ignore=true)
+    private String additionalFieldConsistencyNotReq;
+
+    public String getAdditionalFieldConsistencyReq() {
+        return additionalFieldConsistencyReq;
+    }
+
+    public void setAdditionalFieldConsistencyReq(String additionalFieldConsistencyReq) {
+        this.additionalFieldConsistencyReq = additionalFieldConsistencyReq;
+    }
+
+    public String getAdditionalFieldConsistencyNotReq() {
+        return additionalFieldConsistencyNotReq;
+    }
+
+    public void setAdditionalFieldConsistencyNotReq(String additionalFieldConsistencyNotReq) {
+        this.additionalFieldConsistencyNotReq = additionalFieldConsistencyNotReq;
+    }
+
+}

--- a/utils/src/test/java/com/redhat/lightblue/migrator/utils/consistency/VeryExtendedCountry.java
+++ b/utils/src/test/java/com/redhat/lightblue/migrator/utils/consistency/VeryExtendedCountry.java
@@ -1,0 +1,12 @@
+package com.redhat.lightblue.migrator.utils.consistency;
+
+public class VeryExtendedCountry extends ExtendedCountry {
+
+    public VeryExtendedCountry(Long id, String iso2Code, String inaccessibleFieldConsistencyReq) {
+        super(id, iso2Code);
+        this.inaccessibleFieldConsistencyReq = inaccessibleFieldConsistencyReq;
+    }
+
+    private String inaccessibleFieldConsistencyReq;
+
+}


### PR DESCRIPTION
A utility to compare entities, field by field. Can be optionally used with the facade to ensure consistency between source and destination data.

Using BeanConsistencyChecker requires modification of the entities. This is not always desirable - I'm taking about the case where the facade sits in front of the service bean (rather than the dao) and model classes - also used by the client - are compared for consistency (@luan-cestari, this is what you were working on). Changing equals method and adding some annotations would not be a breaking change for resteasy (client upgrade NOT required), but at some point clients will receive BeanConsistencyChecker dependency. For that reason it might be better to extract it out from lightblue-migration-utils into a separate module.

It is possible to compare beans without modifying them, but that poses a number of challenges. The biggest one is redundant consistency check for deep structures (beans inside beans) and supporting arrays and containers (beans inside arrays and containers). Using equals is a standard and simple solution.