### PR TITLE
Facade supports methods which do both read and write

### DIFF
--- a/utils/src/main/java/com/redhat/lightblue/migrator/utils/DAOFacadeBase.java
+++ b/utils/src/main/java/com/redhat/lightblue/migrator/utils/DAOFacadeBase.java
@@ -56,13 +56,7 @@ public class DAOFacadeBase<D> {
         super();
         this.legacyDAO = legacyDAO;
         this.lightblueDAO = lightblueDAO;
-    }
-
-    public DAOFacadeBase(D legacyDAO, D lightblueDAO, Class entityClass) {
-        this(legacyDAO, lightblueDAO);
-        this.entityIdStore = new EntityIdStoreImpl(entityClass);
-
-        setEntityIdStore(entityIdStore);
+        setEntityIdStore(new EntityIdStoreImpl(this.getClass())); // this.getClass() will point at superclass
     }
 
     private boolean checkConsistency(Object o1, Object o2) {

--- a/utils/src/main/java/com/redhat/lightblue/migrator/utils/DAOFacadeBase.java
+++ b/utils/src/main/java/com/redhat/lightblue/migrator/utils/DAOFacadeBase.java
@@ -87,7 +87,7 @@ public class DAOFacadeBase<D> {
         Iterator<Object> it = Arrays.asList(values).iterator();
         while(it.hasNext()) {
             Object value = it.next();
-            str.append(value.toString());
+            str.append(value);
             if (it.hasNext()) {
                 str.append(", ");
             }

--- a/utils/src/main/java/com/redhat/lightblue/migrator/utils/DAOFacadeBase.java
+++ b/utils/src/main/java/com/redhat/lightblue/migrator/utils/DAOFacadeBase.java
@@ -290,6 +290,7 @@ public class DAOFacadeBase<D> {
     /**
      * Call dao method which creates a single entity. It will ensure that entities in both legacy and lightblue datastores are the same, including IDs.
      *
+     * @param pureWrite method does only write if true. Set it to false if does both read and write.
      * @param returnedType type of the returned object
      * @param methodName method name to call
      * @param types List of parameter types
@@ -297,7 +298,7 @@ public class DAOFacadeBase<D> {
      * @return Object returned by dao
      * @throws Exception
      */
-    public <T> T callDAOCreateSingleMethod(final EntityIdExtractor<T> entityIdExtractor, final Class<T> returnedType, final String methodName, final Class[] types, final Object ... values) throws Exception {
+    public <T> T callDAOCreateSingleMethod(final boolean pureWrite, final EntityIdExtractor<T> entityIdExtractor, final Class<T> returnedType, final String methodName, final Class[] types, final Object ... values) throws Exception {
         log.debug("Creating "+(returnedType!=null?returnedType.getName():"")+" "+methodCallToString(methodName, values));
         TogglzRandomUsername.init();
 
@@ -313,6 +314,12 @@ public class DAOFacadeBase<D> {
             } finally {
                 source.complete();
             }
+        }
+
+        if (!pureWrite && LightblueMigration.shouldWriteSourceEntity() && !LightblueMigration.shouldReadDestinationEntity()) {
+            // dual write phase - use legacy dao, because does also a read
+            log.debug("Dual write phase, skipping lightblueDAO for ."+methodName+" because that method does also a read");
+            return legacyEntity;
         }
 
         if (LightblueMigration.shouldWriteDestinationEntity()) {
@@ -357,8 +364,8 @@ public class DAOFacadeBase<D> {
         return lightblueEntity != null ? lightblueEntity : legacyEntity;
     }
 
-    public <T> T callDAOCreateSingleMethod(final EntityIdExtractor<T> entityIdExtractor, final Class<T> returnedType, final String methodName, final Object ... values) throws Exception {
-        return callDAOCreateSingleMethod(entityIdExtractor, returnedType, methodName, toClasses(values), values);
+    public <T> T callDAOCreateSingleMethod(final boolean pureWrite, final EntityIdExtractor<T> entityIdExtractor, final Class<T> returnedType, final String methodName, final Object ... values) throws Exception {
+        return callDAOCreateSingleMethod(pureWrite, entityIdExtractor, returnedType, methodName, toClasses(values), values);
     }
 
 }

--- a/utils/src/main/java/com/redhat/lightblue/migrator/utils/EntityIdStoreImpl.java
+++ b/utils/src/main/java/com/redhat/lightblue/migrator/utils/EntityIdStoreImpl.java
@@ -11,7 +11,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * EntityIdStore implementation using ehcache. Creates a cache object per entity and uses thread id as key to avoid conflicts.
+ * EntityIdStore implementation using ehcache. Creates a cache object per dao and uses thread id as key to avoid conflicts.
+ * There is an assumption that both legacy and destination daos create entities in the same order.
  *
  * TODO: ehcache.xml will need to be optimized to minimize overhead.
  *
@@ -26,10 +27,10 @@ public class EntityIdStoreImpl implements EntityIdStore {
     private CacheManager cacheManager = CacheManager.create();
     private Cache cache;
 
-    public EntityIdStoreImpl(Class<?> entityClass) {
-        log.debug("Initializing id cache for "+entityClass.getCanonicalName());
-        cacheManager.addCacheIfAbsent(entityClass.getCanonicalName());
-        cache = cacheManager.getCache(entityClass.getCanonicalName());
+    public EntityIdStoreImpl(Class<?> daoClass) {
+        log.debug("Initializing id cache for "+daoClass.getCanonicalName());
+        cacheManager.addCacheIfAbsent(daoClass.getCanonicalName());
+        cache = cacheManager.getCache(daoClass.getCanonicalName());
     }
 
     @Override

--- a/utils/src/test/java/com/redhat/lightblue/migrator/utils/CountryDAO.java
+++ b/utils/src/test/java/com/redhat/lightblue/migrator/utils/CountryDAO.java
@@ -4,6 +4,8 @@ public interface CountryDAO {
 
     public abstract Country createCountry(Country country);
 
+    public abstract Country createCountryIfNotExists(Country country);
+
     public abstract Country updateCountry(Country country);
 
     public abstract Country getCountry(String iso2Code);

--- a/utils/src/test/java/com/redhat/lightblue/migrator/utils/DAOFacadeExample.java
+++ b/utils/src/test/java/com/redhat/lightblue/migrator/utils/DAOFacadeExample.java
@@ -18,7 +18,16 @@ public class DAOFacadeExample extends DAOFacadeBase<CountryDAO> implements Count
     @Override
     public Country createCountry(Country country) {
         try {
-            return callDAOCreateSingleMethod(entityIdExtractor, Country.class, "createCountry", country);
+            return callDAOCreateSingleMethod(true, entityIdExtractor, Country.class, "createCountry", country);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public Country createCountryIfNotExists(Country country) {
+        try {
+            return callDAOCreateSingleMethod(false, entityIdExtractor, Country.class, "createCountryIfNotExists", country);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/utils/src/test/java/com/redhat/lightblue/migrator/utils/DAOFacadeExample.java
+++ b/utils/src/test/java/com/redhat/lightblue/migrator/utils/DAOFacadeExample.java
@@ -12,7 +12,7 @@ public class DAOFacadeExample extends DAOFacadeBase<CountryDAO> implements Count
     };
 
     public DAOFacadeExample(CountryDAO legacyDAO, CountryDAO lightblueDAO) {
-        super(legacyDAO, lightblueDAO, Country.class);
+        super(legacyDAO, lightblueDAO);
     }
 
     @Override

--- a/utils/src/test/java/com/redhat/lightblue/migrator/utils/DAOFacadeTest.java
+++ b/utils/src/test/java/com/redhat/lightblue/migrator/utils/DAOFacadeTest.java
@@ -22,7 +22,6 @@ public class DAOFacadeTest {
 
     @Mock CountryDAO legacyDAO;
     @Mock CountryDAOLightblue lightblueDAO;
-    @Mock EntityIdStore entityIdStore;
     CountryDAO facade;
 
     @Before


### PR DESCRIPTION
Methods which do both read and write are called for destination/lightblue dao in the dual read phase (that differentiates them from pure write methods, which are called in dual write) and ensure id consistency among source and destination (which differentiates them from pure read methods).