### PR TITLE
Consistency check should be done only if both source and destination DAOs are called

### DIFF
--- a/core/src/main/java/com/redhat/lightblue/migrator/features/LightblueMigrationTogglzConfig.java
+++ b/core/src/main/java/com/redhat/lightblue/migrator/features/LightblueMigrationTogglzConfig.java
@@ -1,6 +1,8 @@
 package com.redhat.lightblue.migrator.features;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
@@ -11,6 +13,7 @@ import org.slf4j.LoggerFactory;
 import org.togglz.core.Feature;
 import org.togglz.core.manager.TogglzConfig;
 import org.togglz.core.repository.StateRepository;
+import org.togglz.core.repository.util.DefaultMapSerializer;
 import org.togglz.core.user.UserProvider;
 
 /**
@@ -54,6 +57,19 @@ public class LightblueMigrationTogglzConfig implements TogglzConfig {
     @Override
     public UserProvider getUserProvider() {
         return new TogglzRandomUserProvider();
+    }
+
+    public static void main(String[] args) {
+        DefaultMapSerializer s = DefaultMapSerializer.singleline();
+
+        Map<String,String> params = new HashMap<String,String>();
+        params.put("param", "value");
+
+        String str = s.serialize(params);
+
+        System.out.println(str);
+
+        System.out.println(s.deserialize(str).get("param"));
     }
 
 }

--- a/facade/src/main/java/com/redhat/lightblue/migrator/facade/DAOFacadeBase.java
+++ b/facade/src/main/java/com/redhat/lightblue/migrator/facade/DAOFacadeBase.java
@@ -59,7 +59,7 @@ public class DAOFacadeBase<D> {
         setEntityIdStore(new EntityIdStoreImpl(this.getClass())); // this.getClass() will point at superclass
     }
 
-    private boolean checkConsistency(Object o1, Object o2) {
+    public boolean checkConsistency(Object o1, Object o2) {
         return Objects.equals(o1, o2);
     }
 
@@ -156,7 +156,7 @@ public class DAOFacadeBase<D> {
             }
         }
 
-        if (LightblueMigration.shouldCheckReadConsistency() && LightblueMigration.shouldReadSourceEntity()) {
+        if (LightblueMigration.shouldCheckReadConsistency() && LightblueMigration.shouldReadSourceEntity() &&  LightblueMigration.shouldReadDestinationEntity()) {
             // make sure that response from lightblue and oracle are the same
             log.debug("."+methodName+" checking returned entity's consistency");
             if (checkConsistency(legacyEntity, lightblueEntity)) {
@@ -252,7 +252,7 @@ public class DAOFacadeBase<D> {
             }
         }
 
-        if (LightblueMigration.shouldCheckWriteConsistency() && LightblueMigration.shouldWriteSourceEntity()) {
+        if (LightblueMigration.shouldCheckWriteConsistency() && LightblueMigration.shouldWriteSourceEntity() && LightblueMigration.shouldWriteDestinationEntity()) {
             // make sure that response from lightblue and oracle are the same
             log.debug("."+methodName+" checking returned entity's consistency");
             if (checkConsistency(legacyEntity, lightblueEntity)) {
@@ -346,7 +346,7 @@ public class DAOFacadeBase<D> {
 
         }
 
-        if (LightblueMigration.shouldCheckWriteConsistency() && LightblueMigration.shouldWriteSourceEntity()) {
+        if (LightblueMigration.shouldCheckWriteConsistency() && LightblueMigration.shouldWriteSourceEntity() && LightblueMigration.shouldWriteDestinationEntity()) {
             // make sure that response from lightblue and oracle are the same
             log.debug("."+methodName+" checking returned entity's consistency");
 

--- a/facade/src/test/java/com/redhat/lightblue/migrator/facade/DAOFacadeTest.java
+++ b/facade/src/test/java/com/redhat/lightblue/migrator/facade/DAOFacadeTest.java
@@ -24,12 +24,13 @@ public class DAOFacadeTest {
     @Mock CountryDAO legacyDAO;
     @Mock CountryDAOLightblue lightblueDAO;
     CountryDAO facade;
+    DAOFacadeExample daoFacadeExample;
 
     @Before
     public void setup() {
-        facade = new DAOFacadeExample(legacyDAO, lightblueDAO);
-        Mockito.verify(lightblueDAO).setEntityIdStore(((DAOFacadeBase)facade).getEntityIdStore());
-        //((DAOFacadeBase)facade).setEntityIdStore(entityIdStore);
+        daoFacadeExample = Mockito.spy(new DAOFacadeExample(legacyDAO, lightblueDAO));
+        facade = daoFacadeExample;
+        Mockito.verify(lightblueDAO).setEntityIdStore((daoFacadeExample).getEntityIdStore());
     }
 
     @After
@@ -46,6 +47,7 @@ public class DAOFacadeTest {
 
         facade.getCountry("PL");
 
+        Mockito.verify(daoFacadeExample, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any());
         Mockito.verifyNoMoreInteractions(lightblueDAO);
         Mockito.verify(legacyDAO).getCountry("PL");
     }
@@ -61,6 +63,7 @@ public class DAOFacadeTest {
 
         facade.getCountry("PL");
 
+        Mockito.verify(daoFacadeExample).checkConsistency(Mockito.any(), Mockito.any());
         Mockito.verify(legacyDAO).getCountry("PL");
         Mockito.verify(lightblueDAO).getCountry("PL");
     }
@@ -77,6 +80,7 @@ public class DAOFacadeTest {
 
         Country returnedCountry = facade.getCountry("PL");
 
+        Mockito.verify(daoFacadeExample).checkConsistency(Mockito.any(), Mockito.any());
         Mockito.verify(legacyDAO).getCountry("PL");
         Mockito.verify(lightblueDAO).getCountry("PL");
 
@@ -90,6 +94,7 @@ public class DAOFacadeTest {
 
         facade.getCountry("PL");
 
+        Mockito.verify(daoFacadeExample, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any());
         Mockito.verifyZeroInteractions(legacyDAO);
         Mockito.verify(lightblueDAO).getCountry("PL");
     }
@@ -106,6 +111,7 @@ public class DAOFacadeTest {
 
         Mockito.verifyNoMoreInteractions(lightblueDAO);
         Mockito.verify(legacyDAO).updateCountry(pl);
+        Mockito.verify(daoFacadeExample, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any());
     }
 
     @Test
@@ -118,6 +124,7 @@ public class DAOFacadeTest {
 
         Mockito.verify(legacyDAO).updateCountry(pl);
         Mockito.verify(lightblueDAO).updateCountry(pl);
+        Mockito.verify(daoFacadeExample).checkConsistency(Mockito.any(), Mockito.any());
     }
 
     @Test
@@ -134,6 +141,7 @@ public class DAOFacadeTest {
 
         Mockito.verify(legacyDAO).updateCountry(pl);
         Mockito.verify(lightblueDAO).updateCountry(pl);
+        Mockito.verify(daoFacadeExample).checkConsistency(Mockito.any(), Mockito.any());
 
         // when there is a conflict, facade will return what legacy dao returned
         Assert.assertEquals(ca, updatedEntity);
@@ -149,6 +157,7 @@ public class DAOFacadeTest {
 
         Mockito.verifyZeroInteractions(legacyDAO);
         Mockito.verify(lightblueDAO).updateCountry(pl);
+        Mockito.verify(daoFacadeExample, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any());
     }
 
     /* insert tests */
@@ -163,6 +172,7 @@ public class DAOFacadeTest {
 
         Mockito.verifyZeroInteractions(lightblueDAO);
         Mockito.verify(legacyDAO).createCountry(pl);
+        Mockito.verify(daoFacadeExample, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any());
     }
 
     @Test
@@ -180,6 +190,7 @@ public class DAOFacadeTest {
 
         Mockito.verify(legacyDAO).createCountry(pl);
         Mockito.verify(lightblueDAO).createCountry(pl);
+        Mockito.verify(daoFacadeExample).checkConsistency(Mockito.any(), Mockito.any());
 
         // CountryDAOLightblue should set the id. Since it's just a mock, I'm checking what's in the cache.
         Assert.assertTrue(101l == (Long)((DAOFacadeBase)facade).getEntityIdStore().pop());
@@ -199,6 +210,7 @@ public class DAOFacadeTest {
 
         Mockito.verify(legacyDAO).createCountry(pl);
         Mockito.verify(lightblueDAO).createCountry(pl);
+        Mockito.verify(daoFacadeExample).checkConsistency(Mockito.any(), Mockito.any());
 
         // CountryDAOLightblue should set the id. Since it's just a mock, I'm checking what's in the cache.
         Assert.assertTrue(101l == (Long) ((DAOFacadeBase) facade).getEntityIdStore().pop());
@@ -220,6 +232,7 @@ public class DAOFacadeTest {
 
         Mockito.verifyZeroInteractions(legacyDAO);
         Mockito.verify(lightblueDAO).createCountry(pl);
+        Mockito.verify(daoFacadeExample, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any());
     }
 
     /* insert tests when method also does a read */
@@ -234,6 +247,7 @@ public class DAOFacadeTest {
 
         Mockito.verifyZeroInteractions(lightblueDAO);
         Mockito.verify(legacyDAO).createCountryIfNotExists(pl);
+        Mockito.verify(daoFacadeExample, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any());
     }
 
     @Test
@@ -247,6 +261,8 @@ public class DAOFacadeTest {
         facade.createCountryIfNotExists(pl);
 
         Mockito.verify(legacyDAO).createCountryIfNotExists(pl);
+        Mockito.verify(daoFacadeExample, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any());
+
         // not calling lightblueDAO in dual write phase, because this is also a read method
         Mockito.verifyZeroInteractions(lightblueDAO);
     }
@@ -266,6 +282,7 @@ public class DAOFacadeTest {
 
         Mockito.verify(legacyDAO).createCountryIfNotExists(pl);
         Mockito.verify(lightblueDAO).createCountryIfNotExists(pl);
+        Mockito.verify(daoFacadeExample).checkConsistency(Mockito.any(), Mockito.any());
 
         // CountryDAOLightblue should set the id. Since it's just a mock, I'm checking what's in the cache.
         Assert.assertTrue(101l == (Long)((DAOFacadeBase)facade).getEntityIdStore().pop());
@@ -281,6 +298,7 @@ public class DAOFacadeTest {
 
         Mockito.verifyZeroInteractions(legacyDAO);
         Mockito.verify(lightblueDAO).createCountryIfNotExists(pl);
+        Mockito.verify(daoFacadeExample, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any());
     }
 
     /* lightblue failure tests */

--- a/test/src/main/java/com/redhat/lightblue/migrator/test/LightblueMigrationPhase.java
+++ b/test/src/main/java/com/redhat/lightblue/migrator/test/LightblueMigrationPhase.java
@@ -12,6 +12,17 @@ import com.redhat.lightblue.migrator.features.LightblueMigrationFeatures;
  */
 public abstract class LightblueMigrationPhase {
 
+    public static void enableConsistencyChecks(boolean enable, TogglzRule togglzRule) {
+        if (enable) {
+            togglzRule.enable(LightblueMigrationFeatures.CHECK_WRITE_CONSISTENCY);
+            togglzRule.enable(LightblueMigrationFeatures.CHECK_READ_CONSISTENCY);
+        }
+        else {
+            togglzRule.disable(LightblueMigrationFeatures.CHECK_WRITE_CONSISTENCY);
+            togglzRule.disable(LightblueMigrationFeatures.CHECK_READ_CONSISTENCY);
+        }
+    }
+
     /**
      *
      * @param togglzRule with all features disabled
@@ -19,6 +30,7 @@ public abstract class LightblueMigrationPhase {
     public static void initialPhase(TogglzRule togglzRule) {
         togglzRule.enable(LightblueMigrationFeatures.READ_SOURCE_ENTITY);
         togglzRule.enable(LightblueMigrationFeatures.WRITE_SOURCE_ENTITY);
+        enableConsistencyChecks(true, togglzRule);
     }
 
     /**
@@ -29,7 +41,7 @@ public abstract class LightblueMigrationPhase {
         togglzRule.enable(LightblueMigrationFeatures.READ_SOURCE_ENTITY);
         togglzRule.enable(LightblueMigrationFeatures.WRITE_SOURCE_ENTITY);
         togglzRule.enable(LightblueMigrationFeatures.WRITE_DESTINATION_ENTITY);
-        togglzRule.enable(LightblueMigrationFeatures.CHECK_WRITE_CONSISTENCY);
+        enableConsistencyChecks(true, togglzRule);
     }
 
     /**
@@ -41,8 +53,7 @@ public abstract class LightblueMigrationPhase {
         togglzRule.enable(LightblueMigrationFeatures.WRITE_DESTINATION_ENTITY);
         togglzRule.enable(LightblueMigrationFeatures.READ_SOURCE_ENTITY);
         togglzRule.enable(LightblueMigrationFeatures.READ_DESTINATION_ENTITY);
-        togglzRule.enable(LightblueMigrationFeatures.CHECK_WRITE_CONSISTENCY);
-        togglzRule.enable(LightblueMigrationFeatures.CHECK_READ_CONSISTENCY);
+        enableConsistencyChecks(true, togglzRule);
     }
 
     /**
@@ -52,5 +63,6 @@ public abstract class LightblueMigrationPhase {
     public static void lightblueProxyPhase(TogglzRule togglzRule) {
         togglzRule.enable(LightblueMigrationFeatures.READ_DESTINATION_ENTITY);
         togglzRule.enable(LightblueMigrationFeatures.WRITE_DESTINATION_ENTITY);
+        enableConsistencyChecks(true, togglzRule);
     }
 }


### PR DESCRIPTION
Right now consistency checks are being made also when lightblue is not called, comparing null with what legacy service returns and polluting logs with consistency check errors.