### PR TITLE
Fix #218: EntityIdStore passes cached ids from parent to child thread

### DIFF
--- a/facade/src/main/java/com/redhat/lightblue/migrator/facade/EntityIdStore.java
+++ b/facade/src/main/java/com/redhat/lightblue/migrator/facade/EntityIdStore.java
@@ -13,4 +13,10 @@ public interface EntityIdStore {
 
     public Long pop();
 
+    /**
+     * Copy all key-value pairs from one thread to the other.
+     *
+     */
+    public void copyFromThread(long sourceThreadId);
+
 }

--- a/facade/src/main/java/com/redhat/lightblue/migrator/facade/EntityIdStoreImpl.java
+++ b/facade/src/main/java/com/redhat/lightblue/migrator/facade/EntityIdStoreImpl.java
@@ -86,4 +86,22 @@ public class EntityIdStoreImpl implements EntityIdStore {
         }
     }
 
+    @Override
+    public void copyFromThread(long sourceThreadId) {
+        long threadId = Thread.currentThread().getId();
+        log.debug("Copying key value pairs from thread="+sourceThreadId+" to thread="+threadId);
+
+        Element sourceEl = cache.get(sourceThreadId);
+
+        if (sourceEl == null) {
+            throw new RuntimeException("No ids found for "+cache.getName()+" thread="+sourceThreadId+"!");
+        }
+
+        @SuppressWarnings("unchecked")
+        LinkedList<Long> list = (LinkedList<Long>)sourceEl.getObjectValue();
+
+        // copy by reference
+        cache.put(new Element(threadId, list));
+    }
+
 }

--- a/facade/src/test/java/com/redhat/lightblue/migrator/facade/CountryDAOLightblue.java
+++ b/facade/src/test/java/com/redhat/lightblue/migrator/facade/CountryDAOLightblue.java
@@ -1,6 +1,5 @@
 package com.redhat.lightblue.migrator.facade;
 
-import com.redhat.lightblue.migrator.facade.EntityIdStore;
 
 public interface CountryDAOLightblue extends CountryDAO {
 

--- a/facade/src/test/java/com/redhat/lightblue/migrator/facade/EntityIdStoreImplTest.java
+++ b/facade/src/test/java/com/redhat/lightblue/migrator/facade/EntityIdStoreImplTest.java
@@ -59,6 +59,51 @@ public class EntityIdStoreImplTest {
         store.pop();
     }
 
+    @Test
+    public void testCopy() {
+        EntityIdStoreImpl store = new EntityIdStoreImpl(EntityIdStoreImplTest.class);
+
+        store.push(101l);
+        store.push(102l);
+        store.push(103l);
+
+        TestThread t = new TestThread(store, Thread.currentThread().getId());
+
+        t.start();
+        try {
+            t.join();
+            Assert.assertTrue(t.isChecksPassed());
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+            Assert.fail();
+        }
+
+    }
+
+    class TestThread extends Thread {
+
+        private EntityIdStore store;
+        private Long parentThreadId;
+        private boolean checksPassed = false;
+
+        public TestThread(EntityIdStore store, Long parentThreadId) {
+            super();
+            this.store = store;
+            this.parentThreadId = parentThreadId;
+        }
+
+        @Override
+        public void run() {
+            store.copyFromThread(parentThreadId);
+
+            checksPassed = 101l == store.pop() && 102l == store.pop() && 103l == store.pop();
+        }
+
+        public boolean isChecksPassed() {
+            return checksPassed;
+        }
+    }
+
     @After
     public void clearAll() {
         CacheManager.create().clearAll();


### PR DESCRIPTION
See https://github.com/lightblue-platform/lightblue-migrator/issues/218.