### PR TITLE
Add a possibility to apply the MixIn interface for certain api methods only

### DIFF
--- a/facade/src/main/java/com/redhat/lightblue/migrator/facade/ModelMixIn.java
+++ b/facade/src/main/java/com/redhat/lightblue/migrator/facade/ModelMixIn.java
@@ -6,14 +6,24 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Use <code>ModelMixIn(clazz=Model.class)</code> to map a model object to the jackson Mix-In interface
- * for overriding jackson annotations during bean serialization.
+ * Use <code>ModelMixIn(clazz=Model.class, includeMethods={"apiMethod1","apiMethod2"})</code>
+ * to exclude certain fields from the serialized json before consistency checking.
+ *
  *
  * @author ykoer
- *
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 public @interface ModelMixIn {
+    /**
+     * The MixIn interface/class for a model object.
+     * @return
+     */
     Class clazz();
+
+    /**
+     * Optional attribute allows us to restrict an override to the given method names only.
+     * Otherwise it will be applied to all methods.
+     */
+    String[] includeMethods() default {};
 }

--- a/facade/src/test/java/com/redhat/lightblue/migrator/facade/ConsistencyCheckTest.java
+++ b/facade/src/test/java/com/redhat/lightblue/migrator/facade/ConsistencyCheckTest.java
@@ -17,6 +17,7 @@ import org.togglz.junit.TogglzRule;
 import com.redhat.lightblue.migrator.facade.model.CountryWithDate;
 import com.redhat.lightblue.migrator.facade.model.CountryInCountry;
 import com.redhat.lightblue.migrator.facade.model.CountryWithBigDecimal;
+import com.redhat.lightblue.migrator.facade.model.Person;
 import com.redhat.lightblue.migrator.facade.model.VeryExtendedCountry;
 import com.redhat.lightblue.migrator.facade.model.Country;
 import com.redhat.lightblue.migrator.facade.model.ExtendedCountry;
@@ -192,5 +193,18 @@ public class ConsistencyCheckTest {
 
         Assert.assertTrue(daoFacadeExample.checkConsistency(pl1, pl2));
         Assert.assertTrue(daoFacadeExample.checkConsistency(pl2, pl1));
+    }
+
+    @Test
+    public void testWithMethodInclusion() {
+        Person p1 = new Person("John", "Doe", 35, "British");
+        Person p2 = new Person("John", "Doe", 35, "German");
+        Assert.assertTrue(daoFacadeExample.checkConsistency(p1, p2, "getPerson"));
+        Assert.assertFalse(daoFacadeExample.checkConsistency(p1, p2, "getPerson2"));
+
+        p1 = new Person("John", "Doe", 35, "British");
+        p2 = new Person("John", "Doe", 30, "British");
+        Assert.assertFalse(daoFacadeExample.checkConsistency(p1, p2, "getPerson"));
+        Assert.assertTrue(daoFacadeExample.checkConsistency(p1, p2, "getPerson2"));
     }
 }

--- a/facade/src/test/java/com/redhat/lightblue/migrator/facade/DAOFacadeTest.java
+++ b/facade/src/test/java/com/redhat/lightblue/migrator/facade/DAOFacadeTest.java
@@ -49,7 +49,7 @@ public class DAOFacadeTest {
 
         facade.getCountry("PL");
 
-        Mockito.verify(daoFacadeExample, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any());
+        Mockito.verify(daoFacadeExample, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString());
         Mockito.verifyNoMoreInteractions(lightblueDAO);
         Mockito.verify(legacyDAO).getCountry("PL");
     }
@@ -65,7 +65,7 @@ public class DAOFacadeTest {
 
         facade.getCountry("PL");
 
-        Mockito.verify(daoFacadeExample).checkConsistency(Mockito.any(), Mockito.any());
+        Mockito.verify(daoFacadeExample).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString());
         Mockito.verify(legacyDAO).getCountry("PL");
         Mockito.verify(lightblueDAO).getCountry("PL");
     }
@@ -82,7 +82,7 @@ public class DAOFacadeTest {
 
         Country returnedCountry = facade.getCountry("PL");
 
-        Mockito.verify(daoFacadeExample).checkConsistency(Mockito.any(), Mockito.any());
+        Mockito.verify(daoFacadeExample).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString());
         Mockito.verify(legacyDAO).getCountry("PL");
         Mockito.verify(lightblueDAO).getCountry("PL");
 
@@ -96,7 +96,7 @@ public class DAOFacadeTest {
 
         facade.getCountry("PL");
 
-        Mockito.verify(daoFacadeExample, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any());
+        Mockito.verify(daoFacadeExample, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString());
         Mockito.verifyZeroInteractions(legacyDAO);
         Mockito.verify(lightblueDAO).getCountry("PL");
     }
@@ -113,7 +113,7 @@ public class DAOFacadeTest {
 
         Mockito.verifyNoMoreInteractions(lightblueDAO);
         Mockito.verify(legacyDAO).updateCountry(pl);
-        Mockito.verify(daoFacadeExample, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any());
+        Mockito.verify(daoFacadeExample, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString());
     }
 
     @Test
@@ -126,7 +126,7 @@ public class DAOFacadeTest {
 
         Mockito.verify(legacyDAO).updateCountry(pl);
         Mockito.verify(lightblueDAO).updateCountry(pl);
-        Mockito.verify(daoFacadeExample).checkConsistency(Mockito.any(), Mockito.any());
+        Mockito.verify(daoFacadeExample).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString());
     }
 
     @Test
@@ -143,7 +143,7 @@ public class DAOFacadeTest {
 
         Mockito.verify(legacyDAO).updateCountry(pl);
         Mockito.verify(lightblueDAO).updateCountry(pl);
-        Mockito.verify(daoFacadeExample).checkConsistency(Mockito.any(), Mockito.any());
+        Mockito.verify(daoFacadeExample).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString());
 
         // when there is a conflict, facade will return what legacy dao returned
         Assert.assertEquals(ca, updatedEntity);
@@ -159,7 +159,7 @@ public class DAOFacadeTest {
 
         Mockito.verifyZeroInteractions(legacyDAO);
         Mockito.verify(lightblueDAO).updateCountry(pl);
-        Mockito.verify(daoFacadeExample, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any());
+        Mockito.verify(daoFacadeExample, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString());
     }
 
     /* insert tests */
@@ -174,7 +174,7 @@ public class DAOFacadeTest {
 
         Mockito.verifyZeroInteractions(lightblueDAO);
         Mockito.verify(legacyDAO).createCountry(pl);
-        Mockito.verify(daoFacadeExample, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any());
+        Mockito.verify(daoFacadeExample, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString());
     }
 
     @Test
@@ -192,7 +192,7 @@ public class DAOFacadeTest {
 
         Mockito.verify(legacyDAO).createCountry(pl);
         Mockito.verify(lightblueDAO).createCountry(pl);
-        Mockito.verify(daoFacadeExample).checkConsistency(Mockito.any(), Mockito.any());
+        Mockito.verify(daoFacadeExample).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString());
 
         // CountryDAOLightblue should set the id. Since it's just a mock, I'm checking what's in the cache.
         Assert.assertTrue(101l == (Long)((DAOFacadeBase)facade).getEntityIdStore().pop());
@@ -212,7 +212,7 @@ public class DAOFacadeTest {
 
         Mockito.verify(legacyDAO).createCountry(pl);
         Mockito.verify(lightblueDAO).createCountry(pl);
-        Mockito.verify(daoFacadeExample).checkConsistency(Mockito.any(), Mockito.any());
+        Mockito.verify(daoFacadeExample).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString());
 
         // CountryDAOLightblue should set the id. Since it's just a mock, I'm checking what's in the cache.
         Assert.assertTrue(101l == (Long) ((DAOFacadeBase) facade).getEntityIdStore().pop());
@@ -234,7 +234,7 @@ public class DAOFacadeTest {
 
         Mockito.verifyZeroInteractions(legacyDAO);
         Mockito.verify(lightblueDAO).createCountry(pl);
-        Mockito.verify(daoFacadeExample, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any());
+        Mockito.verify(daoFacadeExample, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString());
     }
 
     /* insert tests when method also does a read */
@@ -249,7 +249,7 @@ public class DAOFacadeTest {
 
         Mockito.verifyZeroInteractions(lightblueDAO);
         Mockito.verify(legacyDAO).createCountryIfNotExists(pl);
-        Mockito.verify(daoFacadeExample, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any());
+        Mockito.verify(daoFacadeExample, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString());
     }
 
     @Test
@@ -263,7 +263,7 @@ public class DAOFacadeTest {
         facade.createCountryIfNotExists(pl);
 
         Mockito.verify(legacyDAO).createCountryIfNotExists(pl);
-        Mockito.verify(daoFacadeExample, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any());
+        Mockito.verify(daoFacadeExample, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString());
 
         // not calling lightblueDAO in dual write phase, because this is also a read method
         Mockito.verifyZeroInteractions(lightblueDAO);
@@ -284,7 +284,7 @@ public class DAOFacadeTest {
 
         Mockito.verify(legacyDAO).createCountryIfNotExists(pl);
         Mockito.verify(lightblueDAO).createCountryIfNotExists(pl);
-        Mockito.verify(daoFacadeExample).checkConsistency(Mockito.any(), Mockito.any());
+        Mockito.verify(daoFacadeExample).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString());
 
         // CountryDAOLightblue should set the id. Since it's just a mock, I'm checking what's in the cache.
         Assert.assertTrue(101l == (Long)((DAOFacadeBase)facade).getEntityIdStore().pop());
@@ -300,7 +300,7 @@ public class DAOFacadeTest {
 
         Mockito.verifyZeroInteractions(legacyDAO);
         Mockito.verify(lightblueDAO).createCountryIfNotExists(pl);
-        Mockito.verify(daoFacadeExample, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any());
+        Mockito.verify(daoFacadeExample, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString());
     }
 
     /* lightblue failure tests */
@@ -398,7 +398,7 @@ public class DAOFacadeTest {
 
         Mockito.verify(lightblueDAO).createCountry(pl);
         Mockito.verify(legacyDAO).createCountry(pl);
-        Mockito.verify(daoFacadeExample).checkConsistency(Mockito.any(), Mockito.any());
+        Mockito.verify(daoFacadeExample).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString());
 
         Assert.assertEquals(pl, returnedCountry);
     }
@@ -425,7 +425,7 @@ public class DAOFacadeTest {
 
         Mockito.verify(lightblueDAO).createCountry(pl);
         Mockito.verify(legacyDAO).createCountry(pl);
-        Mockito.verify(daoFacadeExample).checkConsistency(Mockito.any(), Mockito.any());
+        Mockito.verify(daoFacadeExample).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString());
 
         Assert.assertEquals(pl, returnedCountry);
     }
@@ -452,7 +452,7 @@ public class DAOFacadeTest {
 
         Mockito.verify(lightblueDAO).createCountry(pl);
         Mockito.verify(legacyDAO).createCountry(pl);
-        Mockito.verify(daoFacadeExample, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any());
+        Mockito.verify(daoFacadeExample, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString());
 
         Assert.assertEquals(pl, returnedCountry);
     }
@@ -479,7 +479,7 @@ public class DAOFacadeTest {
 
         Mockito.verify(lightblueDAO).getCountry("PL");
         Mockito.verify(legacyDAO).getCountry("PL");
-        Mockito.verify(daoFacadeExample, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any());
+        Mockito.verify(daoFacadeExample, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString());
 
         Assert.assertEquals(pl, returnedCountry);
     }
@@ -506,9 +506,8 @@ public class DAOFacadeTest {
 
         Mockito.verify(lightblueDAO).updateCountry(pl);
         Mockito.verify(legacyDAO).updateCountry(pl);
-        Mockito.verify(daoFacadeExample, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any());
+        Mockito.verify(daoFacadeExample, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString());
 
         Assert.assertEquals(pl, returnedCountry);
     }
-
 }

--- a/facade/src/test/java/com/redhat/lightblue/migrator/facade/model/Person.java
+++ b/facade/src/test/java/com/redhat/lightblue/migrator/facade/model/Person.java
@@ -1,0 +1,44 @@
+package com.redhat.lightblue.migrator.facade.model;
+
+public class Person {
+
+    public Person() {
+    }
+
+    public Person(String firstName, String lastName, Integer age, String citizenship) {
+        this.firstName = firstName;
+        this.lastName = lastName;
+        this.age = age;
+        this.citizenship = citizenship;
+    }
+
+    private String firstName;
+    private String lastName;
+    private Integer age;
+    private String  citizenship;
+
+    public String getFirstName() {
+        return firstName;
+    }
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+    public String getLastName() {
+        return lastName;
+    }
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+    public Integer getAge() {
+        return age;
+    }
+    public void setAge(Integer age) {
+        this.age = age;
+    }
+    public String getCitizenship() {
+        return citizenship;
+    }
+    public void setCitizenship(String citizenship) {
+        this.citizenship = citizenship;
+    }
+}

--- a/facade/src/test/java/com/redhat/lightblue/migrator/facade/model/Person2MixIn.java
+++ b/facade/src/test/java/com/redhat/lightblue/migrator/facade/model/Person2MixIn.java
@@ -3,8 +3,7 @@ package com.redhat.lightblue.migrator.facade.model;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.redhat.lightblue.migrator.facade.ModelMixIn;
 
-@ModelMixIn(clazz=Country.class)
-public interface CountryMixIn {
-
-    @JsonIgnore Long getName();
+@ModelMixIn(clazz=Person.class, includeMethods="getPerson2")
+public interface Person2MixIn {
+    @JsonIgnore Integer getAge();
 }

--- a/facade/src/test/java/com/redhat/lightblue/migrator/facade/model/PersonMixIn.java
+++ b/facade/src/test/java/com/redhat/lightblue/migrator/facade/model/PersonMixIn.java
@@ -3,8 +3,7 @@ package com.redhat.lightblue.migrator.facade.model;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.redhat.lightblue.migrator.facade.ModelMixIn;
 
-@ModelMixIn(clazz=Country.class)
-public interface CountryMixIn {
-
-    @JsonIgnore Long getName();
+@ModelMixIn(clazz=Person.class, includeMethods="getPerson")
+public interface PersonMixIn {
+    @JsonIgnore String getCitizenship();
 }


### PR DESCRIPTION
There is a new optional property "includeMethods" for ModelMix annotation which allows us to apply the MixIn only to certain methods. Non existing property will apply the MixIn to all method calls.