### PR TITLE
Improving inconsistency logging

### DIFF
--- a/facade/src/main/java/com/redhat/lightblue/migrator/facade/DAOFacadeBase.java
+++ b/facade/src/main/java/com/redhat/lightblue/migrator/facade/DAOFacadeBase.java
@@ -92,7 +92,7 @@ public class DAOFacadeBase<D> {
                 mapper.addMixInAnnotations(entry.getValue().clazz(), entry.getKey());
             }
         }
-        return mapper.writer().withDefaultPrettyPrinter();
+        return mapper.writer();
     }
 
     // user for unit testing
@@ -117,7 +117,7 @@ public class DAOFacadeBase<D> {
                 log.debug("Consistency check passed: "+ result.passed());
             }
             if (!result.passed()) {
-                log.warn(String.format("Inconsistency found in %s:\n%s\nlegacyJson=%s\nlightblueJson=%s", callToLogInCaseOfInconsistency, result.getMessage(), legacyJson, lightblueJson));
+                log.warn(String.format("Inconsistency found in %s:%s legacyJson: %s, lightblueJson: %s", callToLogInCaseOfInconsistency, result.getMessage().replaceAll("\n", ","), legacyJson, lightblueJson));
             }
             return result.passed();
         } catch (Exception e) {

--- a/facade/src/main/java/com/redhat/lightblue/migrator/facade/DAOFacadeBase.java
+++ b/facade/src/main/java/com/redhat/lightblue/migrator/facade/DAOFacadeBase.java
@@ -104,10 +104,10 @@ public class DAOFacadeBase<D> {
             return true;
         }
         try {
+            long t1 = System.currentTimeMillis();
             String legacyJson = getObjectWriter(methodName).writeValueAsString(o1);
             String lightblueJson = getObjectWriter(methodName).writeValueAsString(o2);
 
-            long t1 = System.currentTimeMillis();
             JSONCompareResult result = JSONCompare.compareJSON(legacyJson, lightblueJson, JSONCompareMode.LENIENT);
             long t2 = System.currentTimeMillis();
 

--- a/facade/src/main/java/com/redhat/lightblue/migrator/facade/DAOFacadeBase.java
+++ b/facade/src/main/java/com/redhat/lightblue/migrator/facade/DAOFacadeBase.java
@@ -144,7 +144,10 @@ public class DAOFacadeBase<D> {
         Iterator<Object> it = Arrays.asList(values).iterator();
         while(it.hasNext()) {
             Object value = it.next();
-            str.append(value);
+            if (value != null && value.getClass().isArray())
+                str.append(Arrays.deepToString((Object[])value));
+            else
+                str.append(value);
             if (it.hasNext()) {
                 str.append(", ");
             }
@@ -196,7 +199,8 @@ public class DAOFacadeBase<D> {
      * @throws Exception
      */
     public <T> T callDAOReadMethod(final Class<T> returnedType, final String methodName, final Class[] types, final Object ... values) throws Throwable {
-        log.debug("Reading "+returnedType.getName()+" "+methodCallToString(methodName, values));
+        if (log.isDebugEnabled())
+            log.debug("Reading "+returnedType.getName()+" "+methodCallToString(methodName, values));
         TogglzRandomUsername.init();
 
         T legacyEntity = null, lightblueEntity = null;
@@ -278,7 +282,8 @@ public class DAOFacadeBase<D> {
      * @throws Exception
      */
     public <T> T callDAOUpdateMethod(final Class<T> returnedType, final String methodName, final Class[] types, final Object ... values) throws Throwable {
-        log.debug("Writing "+(returnedType!=null?returnedType.getName():"")+" "+methodCallToString(methodName, values));
+        if (log.isDebugEnabled())
+            log.debug("Writing "+(returnedType!=null?returnedType.getName():"")+" "+methodCallToString(methodName, values));
         TogglzRandomUsername.init();
 
         T legacyEntity = null, lightblueEntity = null;
@@ -356,7 +361,8 @@ public class DAOFacadeBase<D> {
      * @throws Exception
      */
     public <T> T callDAOCreateSingleMethod(final boolean pureWrite, final EntityIdExtractor<T> entityIdExtractor, final Class<T> returnedType, final String methodName, final Class[] types, final Object ... values) throws Throwable {
-        log.debug("Creating "+(returnedType!=null?returnedType.getName():"")+" "+methodCallToString(methodName, values));
+        if (log.isDebugEnabled())
+            log.debug("Creating "+(returnedType!=null?returnedType.getName():"")+" "+methodCallToString(methodName, values));
         TogglzRandomUsername.init();
 
         T legacyEntity = null, lightblueEntity = null;

--- a/facade/src/test/java/com/redhat/lightblue/migrator/facade/ConsistencyCheckTest.java
+++ b/facade/src/test/java/com/redhat/lightblue/migrator/facade/ConsistencyCheckTest.java
@@ -199,12 +199,12 @@ public class ConsistencyCheckTest {
     public void testWithMethodInclusion() {
         Person p1 = new Person("John", "Doe", 35, "British");
         Person p2 = new Person("John", "Doe", 35, "German");
-        Assert.assertTrue(daoFacadeExample.checkConsistency(p1, p2, "getPerson"));
-        Assert.assertFalse(daoFacadeExample.checkConsistency(p1, p2, "getPerson2"));
+        Assert.assertTrue(daoFacadeExample.checkConsistency(p1, p2, "getPerson", null));
+        Assert.assertFalse(daoFacadeExample.checkConsistency(p1, p2, "getPerson2", null));
 
         p1 = new Person("John", "Doe", 35, "British");
         p2 = new Person("John", "Doe", 30, "British");
-        Assert.assertFalse(daoFacadeExample.checkConsistency(p1, p2, "getPerson"));
-        Assert.assertTrue(daoFacadeExample.checkConsistency(p1, p2, "getPerson2"));
+        Assert.assertFalse(daoFacadeExample.checkConsistency(p1, p2, "getPerson", null));
+        Assert.assertTrue(daoFacadeExample.checkConsistency(p1, p2, "getPerson2", null));
     }
 }

--- a/facade/src/test/java/com/redhat/lightblue/migrator/facade/DAOFacadeTest.java
+++ b/facade/src/test/java/com/redhat/lightblue/migrator/facade/DAOFacadeTest.java
@@ -49,7 +49,7 @@ public class DAOFacadeTest {
 
         facade.getCountry("PL");
 
-        Mockito.verify(daoFacadeExample, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString());
+        Mockito.verify(daoFacadeExample, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString());
         Mockito.verifyNoMoreInteractions(lightblueDAO);
         Mockito.verify(legacyDAO).getCountry("PL");
     }
@@ -65,7 +65,7 @@ public class DAOFacadeTest {
 
         facade.getCountry("PL");
 
-        Mockito.verify(daoFacadeExample).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString());
+        Mockito.verify(daoFacadeExample).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString());
         Mockito.verify(legacyDAO).getCountry("PL");
         Mockito.verify(lightblueDAO).getCountry("PL");
     }
@@ -82,7 +82,7 @@ public class DAOFacadeTest {
 
         Country returnedCountry = facade.getCountry("PL");
 
-        Mockito.verify(daoFacadeExample).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString());
+        Mockito.verify(daoFacadeExample).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString());
         Mockito.verify(legacyDAO).getCountry("PL");
         Mockito.verify(lightblueDAO).getCountry("PL");
 
@@ -96,7 +96,7 @@ public class DAOFacadeTest {
 
         facade.getCountry("PL");
 
-        Mockito.verify(daoFacadeExample, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString());
+        Mockito.verify(daoFacadeExample, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString());
         Mockito.verifyZeroInteractions(legacyDAO);
         Mockito.verify(lightblueDAO).getCountry("PL");
     }
@@ -113,7 +113,7 @@ public class DAOFacadeTest {
 
         Mockito.verifyNoMoreInteractions(lightblueDAO);
         Mockito.verify(legacyDAO).updateCountry(pl);
-        Mockito.verify(daoFacadeExample, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString());
+        Mockito.verify(daoFacadeExample, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString());
     }
 
     @Test
@@ -126,7 +126,7 @@ public class DAOFacadeTest {
 
         Mockito.verify(legacyDAO).updateCountry(pl);
         Mockito.verify(lightblueDAO).updateCountry(pl);
-        Mockito.verify(daoFacadeExample).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString());
+        Mockito.verify(daoFacadeExample).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString());
     }
 
     @Test
@@ -143,7 +143,7 @@ public class DAOFacadeTest {
 
         Mockito.verify(legacyDAO).updateCountry(pl);
         Mockito.verify(lightblueDAO).updateCountry(pl);
-        Mockito.verify(daoFacadeExample).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString());
+        Mockito.verify(daoFacadeExample).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString());
 
         // when there is a conflict, facade will return what legacy dao returned
         Assert.assertEquals(ca, updatedEntity);
@@ -159,7 +159,7 @@ public class DAOFacadeTest {
 
         Mockito.verifyZeroInteractions(legacyDAO);
         Mockito.verify(lightblueDAO).updateCountry(pl);
-        Mockito.verify(daoFacadeExample, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString());
+        Mockito.verify(daoFacadeExample, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString());
     }
 
     /* insert tests */
@@ -174,7 +174,7 @@ public class DAOFacadeTest {
 
         Mockito.verifyZeroInteractions(lightblueDAO);
         Mockito.verify(legacyDAO).createCountry(pl);
-        Mockito.verify(daoFacadeExample, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString());
+        Mockito.verify(daoFacadeExample, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString());
     }
 
     @Test
@@ -192,7 +192,7 @@ public class DAOFacadeTest {
 
         Mockito.verify(legacyDAO).createCountry(pl);
         Mockito.verify(lightblueDAO).createCountry(pl);
-        Mockito.verify(daoFacadeExample).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString());
+        Mockito.verify(daoFacadeExample).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString());
 
         // CountryDAOLightblue should set the id. Since it's just a mock, I'm checking what's in the cache.
         Assert.assertTrue(101l == (Long)((DAOFacadeBase)facade).getEntityIdStore().pop());
@@ -212,7 +212,7 @@ public class DAOFacadeTest {
 
         Mockito.verify(legacyDAO).createCountry(pl);
         Mockito.verify(lightblueDAO).createCountry(pl);
-        Mockito.verify(daoFacadeExample).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString());
+        Mockito.verify(daoFacadeExample).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString());
 
         // CountryDAOLightblue should set the id. Since it's just a mock, I'm checking what's in the cache.
         Assert.assertTrue(101l == (Long) ((DAOFacadeBase) facade).getEntityIdStore().pop());
@@ -234,7 +234,7 @@ public class DAOFacadeTest {
 
         Mockito.verifyZeroInteractions(legacyDAO);
         Mockito.verify(lightblueDAO).createCountry(pl);
-        Mockito.verify(daoFacadeExample, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString());
+        Mockito.verify(daoFacadeExample, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString());
     }
 
     /* insert tests when method also does a read */
@@ -249,7 +249,7 @@ public class DAOFacadeTest {
 
         Mockito.verifyZeroInteractions(lightblueDAO);
         Mockito.verify(legacyDAO).createCountryIfNotExists(pl);
-        Mockito.verify(daoFacadeExample, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString());
+        Mockito.verify(daoFacadeExample, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString());
     }
 
     @Test
@@ -263,7 +263,7 @@ public class DAOFacadeTest {
         facade.createCountryIfNotExists(pl);
 
         Mockito.verify(legacyDAO).createCountryIfNotExists(pl);
-        Mockito.verify(daoFacadeExample, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString());
+        Mockito.verify(daoFacadeExample, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString());
 
         // not calling lightblueDAO in dual write phase, because this is also a read method
         Mockito.verifyZeroInteractions(lightblueDAO);
@@ -284,7 +284,7 @@ public class DAOFacadeTest {
 
         Mockito.verify(legacyDAO).createCountryIfNotExists(pl);
         Mockito.verify(lightblueDAO).createCountryIfNotExists(pl);
-        Mockito.verify(daoFacadeExample).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString());
+        Mockito.verify(daoFacadeExample).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString());
 
         // CountryDAOLightblue should set the id. Since it's just a mock, I'm checking what's in the cache.
         Assert.assertTrue(101l == (Long)((DAOFacadeBase)facade).getEntityIdStore().pop());
@@ -300,7 +300,7 @@ public class DAOFacadeTest {
 
         Mockito.verifyZeroInteractions(legacyDAO);
         Mockito.verify(lightblueDAO).createCountryIfNotExists(pl);
-        Mockito.verify(daoFacadeExample, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString());
+        Mockito.verify(daoFacadeExample, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString());
     }
 
     /* lightblue failure tests */
@@ -398,7 +398,7 @@ public class DAOFacadeTest {
 
         Mockito.verify(lightblueDAO).createCountry(pl);
         Mockito.verify(legacyDAO).createCountry(pl);
-        Mockito.verify(daoFacadeExample).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString());
+        Mockito.verify(daoFacadeExample).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString());
 
         Assert.assertEquals(pl, returnedCountry);
     }
@@ -425,7 +425,7 @@ public class DAOFacadeTest {
 
         Mockito.verify(lightblueDAO).createCountry(pl);
         Mockito.verify(legacyDAO).createCountry(pl);
-        Mockito.verify(daoFacadeExample).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString());
+        Mockito.verify(daoFacadeExample).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString());
 
         Assert.assertEquals(pl, returnedCountry);
     }
@@ -452,7 +452,7 @@ public class DAOFacadeTest {
 
         Mockito.verify(lightblueDAO).createCountry(pl);
         Mockito.verify(legacyDAO).createCountry(pl);
-        Mockito.verify(daoFacadeExample, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString());
+        Mockito.verify(daoFacadeExample, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString());
 
         Assert.assertEquals(pl, returnedCountry);
     }
@@ -479,7 +479,7 @@ public class DAOFacadeTest {
 
         Mockito.verify(lightblueDAO).getCountry("PL");
         Mockito.verify(legacyDAO).getCountry("PL");
-        Mockito.verify(daoFacadeExample, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString());
+        Mockito.verify(daoFacadeExample, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString());
 
         Assert.assertEquals(pl, returnedCountry);
     }
@@ -506,7 +506,7 @@ public class DAOFacadeTest {
 
         Mockito.verify(lightblueDAO).updateCountry(pl);
         Mockito.verify(legacyDAO).updateCountry(pl);
-        Mockito.verify(daoFacadeExample, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString());
+        Mockito.verify(daoFacadeExample, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString());
 
         Assert.assertEquals(pl, returnedCountry);
     }


### PR DESCRIPTION
Inconsistencies should be logged at WARN level (because those are errors which do not affect application users), at DEBUG level we wouldn't be able to monitor them effectively due to the overall verbosity of the DEBUG level.

Logging not only the diff, but also legacy and lightblue pojos (in json format) and method which returned inconsistent results, along with parameters used to call it.

Logging in a single line - this is how splunk likes it.