### PR TITLE
Handling inconsistency logging for methods with primitive arrays

### DIFF
--- a/facade/src/test/java/com/redhat/lightblue/migrator/facade/CountryDAO.java
+++ b/facade/src/test/java/com/redhat/lightblue/migrator/facade/CountryDAO.java
@@ -12,4 +12,6 @@ public interface CountryDAO {
 
     public abstract Country getCountry(String iso2Code) throws CountryException;
 
+    public abstract Country getCountries(long[] ids) throws CountryException;
+
 }

--- a/facade/src/test/java/com/redhat/lightblue/migrator/facade/DAOFacadeExample.java
+++ b/facade/src/test/java/com/redhat/lightblue/migrator/facade/DAOFacadeExample.java
@@ -66,4 +66,15 @@ public class DAOFacadeExample extends DAOFacadeBase<CountryDAO> implements Count
         }
     }
 
+    @Override
+    public Country getCountries(long[] ids) throws CountryException {
+        try {
+            return callDAOReadMethod(Country.class, "getCountries", ids);
+        } catch (CountryException ce) {
+            throw ce;
+        } catch (Throwable t) {
+            throw new RuntimeException(t);
+        }
+    }
+
 }

--- a/facade/src/test/java/com/redhat/lightblue/migrator/facade/DAOFacadeTest.java
+++ b/facade/src/test/java/com/redhat/lightblue/migrator/facade/DAOFacadeTest.java
@@ -91,6 +91,28 @@ public class DAOFacadeTest {
     }
 
     @Test
+    public void dualReadPhaseReadInconsistentPrimitiveArrayTest() throws CountryException {
+        LightblueMigrationPhase.dualReadPhase(togglzRule);
+
+        Country pl = new Country(1l, "PL");
+        Country ca = new Country(2l, "CA");
+
+        long[] ids = new long[]{1l,2l,3l};
+
+        Mockito.when(legacyDAO.getCountries(ids)).thenReturn(ca);
+        Mockito.when(lightblueDAO.getCountries(ids)).thenReturn(pl);
+
+        Country returnedCountry = facade.getCountries(ids);
+
+        Mockito.verify(daoFacadeExample).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString());
+        Mockito.verify(legacyDAO).getCountries(ids);
+        Mockito.verify(lightblueDAO).getCountries(ids);
+
+        // when there is a conflict, facade will return what legacy dao returned
+        Assert.assertEquals(ca, returnedCountry);
+    }
+
+    @Test
     public void lightblueProxyTest() throws CountryException {
         LightblueMigrationPhase.lightblueProxyPhase(togglzRule);
 

--- a/facade/src/test/java/com/redhat/lightblue/migrator/facade/MethodCallStringifierTest.java
+++ b/facade/src/test/java/com/redhat/lightblue/migrator/facade/MethodCallStringifierTest.java
@@ -1,0 +1,55 @@
+package com.redhat.lightblue.migrator.facade;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.redhat.lightblue.migrator.facade.model.Country;
+
+public class MethodCallStringifierTest {
+
+    @Test
+    public void testSimple() {
+        Assert.assertEquals("blah(12, string)",
+                DAOFacadeBase.methodCallToString("blah", new Object[]{12, "string"}));
+    }
+
+    @Test
+    public void testListOfObjects() {
+        List<Country> l = new ArrayList<>();
+        l.add(new Country(1l, "PL"));
+        l.add(new Country(2l, "CA"));
+
+        Assert.assertEquals("blah([PL, CA], 12, string)",
+                DAOFacadeBase.methodCallToString("blah", new Object[]{l, 12, "string"}));
+    }
+
+    @Test
+    public void testListOfPrimitives() {
+        List<Long> l = new ArrayList<>();
+        l.add(1l);
+        l.add(2l);
+
+        Assert.assertEquals("blah([1, 2], 12, string)",
+                DAOFacadeBase.methodCallToString("blah", new Object[]{l, 12, "string"}));
+    }
+
+    @Test
+    public void testArrayOfPrimitives() {
+        Long[] arr = new Long[]{1l, 2l};
+
+        Assert.assertEquals("blah([1, 2], 12, string)",
+                DAOFacadeBase.methodCallToString("blah", new Object[]{arr, 12, "string"}));
+    }
+
+    @Test
+    public void testArrayOfObjects() {
+        Country[] arr = new Country[]{new Country(1l, "PL"), new Country(2l, "CA")};
+
+        Assert.assertEquals("blah([PL, CA], 12, string)",
+                DAOFacadeBase.methodCallToString("blah", new Object[]{arr, 12, "string"}));
+    }
+
+}

--- a/facade/src/test/java/com/redhat/lightblue/migrator/facade/model/Country.java
+++ b/facade/src/test/java/com/redhat/lightblue/migrator/facade/model/Country.java
@@ -49,4 +49,9 @@ public class Country {
         this.iso3Code = iso3code;
     }
 
+    @Override
+    public String toString() {
+        return iso2Code;
+    }
+
 }


### PR DESCRIPTION
This is a fix to ```java.lang.ClassCastException: [J cannot be cast to [Ljava.lang.Object;``` exceptions when logging inconsistencies for methods with arrays of primitives as parameters.

Having to handle primitives and objects differently sucks. One more reason to use scala.