### PR TITLE
Fix #249: Handle exceptions properly in lightblue proxy phase of the migration 

### DIFF
--- a/facade/src/test/java/com/redhat/lightblue/migrator/facade/DAOFacadeExample.java
+++ b/facade/src/test/java/com/redhat/lightblue/migrator/facade/DAOFacadeExample.java
@@ -1,11 +1,6 @@
 package com.redhat.lightblue.migrator.facade;
 
-import javax.management.RuntimeErrorException;
-
-import com.redhat.lightblue.migrator.facade.DAOFacadeBase;
-import com.redhat.lightblue.migrator.facade.EntityIdExtractor;
 import com.redhat.lightblue.migrator.facade.model.Country;
-
 
 
 public class DAOFacadeExample extends DAOFacadeBase<CountryDAO> implements CountryDAO {

--- a/facade/src/test/java/com/redhat/lightblue/migrator/facade/DAOFacadeTest.java
+++ b/facade/src/test/java/com/redhat/lightblue/migrator/facade/DAOFacadeTest.java
@@ -380,6 +380,67 @@ public class DAOFacadeTest {
     }
 
     @Test
+    public void ligtblueFailureDuringReadProxyPhaseTest() throws CountryException {
+        LightblueMigrationPhase.lightblueProxyPhase(togglzRule);
+
+        Mockito.doThrow(new CountryException()).when(lightblueDAO).getCountry("PL");
+
+        try {
+            facade.getCountry("PL");
+            Assert.fail();
+        } catch(CountryException ce) {
+
+        } catch(Exception e) {
+            Assert.fail();
+        }
+
+        Mockito.verify(lightblueDAO).getCountry("PL");
+
+    }
+
+    @Test
+    public void ligtblueFailureDuringCreateProxyPhaseTest() throws CountryException {
+        LightblueMigrationPhase.lightblueProxyPhase(togglzRule);
+
+        Country pl = new Country(101l, "PL");
+
+        Mockito.doThrow(new CountryException()).when(lightblueDAO).createCountry(pl);
+
+        try {
+            facade.createCountry(pl);
+            Assert.fail();
+        } catch(CountryException ce) {
+
+        } catch(Exception e) {
+            Assert.fail();
+        }
+
+        Mockito.verify(lightblueDAO).createCountry(pl);
+
+    }
+
+    @Test
+    public void ligtblueFailureDuringUpdateProxyPhaseTest() throws CountryException {
+        LightblueMigrationPhase.lightblueProxyPhase(togglzRule);
+
+        Country pl = new Country(101l, "PL");
+
+        Mockito.doThrow(new CountryException()).when(lightblueDAO).updateCountry(pl);
+
+        try {
+            facade.updateCountry(pl);
+            Assert.fail();
+        } catch(CountryException ce) {
+
+        } catch(Exception e) {
+            Assert.fail();
+        }
+
+        Mockito.verify(lightblueDAO).updateCountry(pl);
+
+    }
+
+    @Test
     public void lightblueNullReturnedAfterCreateTest() throws CountryException {
         LightblueMigrationPhase.dualReadPhase(togglzRule);
 


### PR DESCRIPTION
There are no unit tests for timeout scenario, but timeouts don't make sense in the proxy phase (when only lightblue is available), so I just assume timeouts will be turned off.