### PR TITLE
Allow dynamic proxy interface to be a child of the dao interfaces. A …

### DIFF
--- a/facade/src/main/java/com/redhat/lightblue/migrator/facade/proxy/FacadeProxyFactory.java
+++ b/facade/src/main/java/com/redhat/lightblue/migrator/facade/proxy/FacadeProxyFactory.java
@@ -109,11 +109,11 @@ public class FacadeProxyFactory {
     }
 
     @SuppressWarnings("unchecked")
-    public static <D> D createFacadeProxy(DAOFacadeBase<D> daoFacadeBase, Class<D> daoClass) throws InstantiationException, IllegalAccessException {
+    public static <D> D createFacadeProxy(DAOFacadeBase<D> daoFacadeBase, Class<? extends D> daoClass) throws InstantiationException, IllegalAccessException {
         return (D) Proxy.newProxyInstance(daoClass.getClassLoader(), new Class[] {daoClass}, new FacadeInvocationHandler<D>(daoFacadeBase));
     }
 
-    public static <D> D createFacadeProxy(D legacyDAO, D lightblueDAO, Class<D> daoClass) throws InstantiationException, IllegalAccessException {
+    public static <D> D createFacadeProxy(D legacyDAO, D lightblueDAO, Class<? extends D> daoClass) throws InstantiationException, IllegalAccessException {
         return createFacadeProxy(new DAOFacadeBase<D>(legacyDAO, lightblueDAO), daoClass);
     }
 


### PR DESCRIPTION
…child is useful to define the facade annotations.