### PR TITLE
Facade should not log huge inconsistencies into server.log

### DIFF
--- a/facade/src/main/java/com/redhat/lightblue/migrator/facade/AbstractServiceFacade.java
+++ b/facade/src/main/java/com/redhat/lightblue/migrator/facade/AbstractServiceFacade.java
@@ -1,0 +1,147 @@
+package com.redhat.lightblue.migrator.facade;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.json.JSONException;
+import org.reflections.Reflections;
+import org.skyscreamer.jsonassert.JSONCompare;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+import org.skyscreamer.jsonassert.JSONCompareResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+
+/**
+ * An abstract base class for Service Facade which handles inconsistencies and logging.
+ *
+ * @author ykoer
+ *
+ */
+public abstract class AbstractServiceFacade {
+
+    protected static final Logger log = LoggerFactory.getLogger(AbstractServiceFacade.class);
+    private static final Logger inconsistencyLog = LoggerFactory.getLogger("Inconsistency");
+
+    // used to associate inconsistencies with the service in the logs
+    protected String implementationName;
+    protected int maxInconsistencyLogLength = 65536; // 64KB
+    protected boolean logData = true;
+    private Map<Class<?>,ModelMixIn> modelMixIns;
+
+    private Map<Class<?>,ModelMixIn> findModelMixInMappings() {
+        if  (modelMixIns==null) {
+            Reflections reflections = new Reflections("");
+            Set<Class<?>> classes = reflections.getTypesAnnotatedWith(ModelMixIn.class);
+            modelMixIns = new HashMap<>();
+            for (Class<?> clazz : classes) {
+                modelMixIns.put(clazz, clazz.getAnnotation(ModelMixIn.class));
+            }
+        }
+        return modelMixIns;
+    }
+
+    private ObjectWriter getObjectWriter(String methodName) {
+        ObjectMapper mapper = new ObjectMapper();
+        for (Map.Entry<Class<?>, ModelMixIn> entry : findModelMixInMappings().entrySet()) {
+            if (methodName==null || entry.getValue().includeMethods().length==0 || Arrays.asList(entry.getValue().includeMethods()).contains(methodName)) {
+                mapper.addMixInAnnotations(entry.getValue().clazz(), entry.getKey());
+            }
+        }
+        return mapper.writer();
+    }
+
+    /* If logData=true:
+     *     - Log message < MAX_INCONSISTENCY_LOG_LENGTH to server.log.
+     *     - Log message > MAX_INCONSISTENCY_LOG_LENGTH and diff <= MAX_INCONSISTENCY_LOG_LENGTH, log diff to server.log.
+     *     - Otherwise log method name and parameters to server.log and full message to inconsistency.log.
+     * If logData=false:
+     *     - diff <= MAX_INCONSISTENCY_LOG_LENGTH, log diff to server.log.
+     *     - Otherwise log method name and parameters to server.log
+     *     - Always log full message to inconsistency.log
+     */
+    private void logInconsistency(String callToLogInCaseOfInconsistency, String legacyJson, String lightblueJson, String diff) {
+        String logMessage = String.format("Inconsistency found in %s.%s - diff: %s legacyJson: %s, lightblueJson: %s", implementationName, callToLogInCaseOfInconsistency, diff, legacyJson, lightblueJson);
+
+        if (logData) {
+            if (logMessage.length()<=maxInconsistencyLogLength) {
+                log.warn(logMessage);
+            } else if (diff!=null&&diff.length()<=maxInconsistencyLogLength) {
+                log.warn(String.format("Inconsistency found in %s.%s - diff: %s", implementationName, callToLogInCaseOfInconsistency, diff));
+            } else {
+                log.warn(String.format("Inconsistency found in %s.%s - payload and diff is greater than %d bytes!", implementationName, callToLogInCaseOfInconsistency, maxInconsistencyLogLength));
+                inconsistencyLog.debug(logMessage); // logging at debug level since everything >= info would also land in server.log
+            }
+        } else {
+            if (diff!=null&&diff.length()<=maxInconsistencyLogLength) {
+                log.warn(String.format("Inconsistency found in %s.%s - diff: %s", implementationName, callToLogInCaseOfInconsistency, diff));
+            } else {
+                log.warn(String.format("Inconsistency found in %s.%s - diff is greater than %d bytes!", implementationName, callToLogInCaseOfInconsistency, maxInconsistencyLogLength));
+            }
+            // logData is turned off, log in inconsistency.log for debugging
+            inconsistencyLog.debug(logMessage);
+        }
+    }
+
+    // convenience method for unit testing
+    protected boolean checkConsistency(Object o1, Object o2) {
+        return checkConsistency(o1, o2, null, null);
+    }
+
+    /**
+     * Check that objects are equal using org.skyscreamer.jsonassert library.
+     *
+     * @param o1                              object returned from legacy call
+     * @param o2                              object returned from lightblue call
+     * @param methodName                      the method name
+     * @param callToLogInCaseOfInconsistency  the call including parameters
+     * @return
+     */
+    protected boolean checkConsistency(final Object o1, final Object o2, String methodName, String callToLogInCaseOfInconsistency) {
+        if (o1==null&&o2==null) {
+            return true;
+        }
+
+        String legacyJson=null;
+        String lightblueJson=null;
+        try {
+            long t1 = System.currentTimeMillis();
+            legacyJson = getObjectWriter(methodName).writeValueAsString(o1);
+            lightblueJson = getObjectWriter(methodName).writeValueAsString(o2);
+
+            JSONCompareResult result = JSONCompare.compareJSON(legacyJson, lightblueJson, JSONCompareMode.LENIENT);
+            long t2 = System.currentTimeMillis();
+
+            if (log.isDebugEnabled()) {
+                log.debug("Consistency check took: " + (t2-t1)+" ms");
+                log.debug("Consistency check passed: "+ result.passed());
+            }
+            if (!result.passed()) {
+                logInconsistency(callToLogInCaseOfInconsistency, legacyJson, lightblueJson, result.getMessage().replaceAll("\n", ","));
+            }
+            return result.passed();
+        } catch (JSONException e) {
+            if (o1!=null&&o1.equals(o2)) {
+                return true;
+            } else {
+                logInconsistency(callToLogInCaseOfInconsistency, legacyJson, lightblueJson, null);
+            }
+        } catch (JsonProcessingException e) {
+            log.error("Consistency check failed! Invalid JSON. ", e);
+        }
+        return false;
+    }
+
+    public void setMaxInconsistencyLogLength(int length) {
+        this.maxInconsistencyLogLength = length;
+    }
+
+    public void setLogData(boolean logData) {
+        this.logData = logData;
+    }
+}

--- a/facade/src/main/java/com/redhat/lightblue/migrator/facade/DAOFacadeBase.java
+++ b/facade/src/main/java/com/redhat/lightblue/migrator/facade/DAOFacadeBase.java
@@ -5,28 +5,14 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import org.json.JSONException;
-import org.reflections.Reflections;
-import org.skyscreamer.jsonassert.JSONCompare;
-import org.skyscreamer.jsonassert.JSONCompareMode;
-import org.skyscreamer.jsonassert.JSONCompareResult;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectWriter;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
@@ -46,23 +32,13 @@ import com.redhat.lightblue.migrator.features.TogglzRandomUsername;
  */
 @SuppressWarnings("all")
 @Deprecated
-public class DAOFacadeBase<D> {
-
-    private static final Logger log = LoggerFactory.getLogger(DAOFacadeBase.class);
-    private static final Logger logInconsisteny = LoggerFactory.getLogger("Inconsistency");
+public class DAOFacadeBase<D> extends AbstractServiceFacade {
 
     protected final D legacyDAO, lightblueDAO;
 
     private EntityIdStore entityIdStore = null;
 
-    private Map<Class<?>,ModelMixIn> modelMixIns;
-
     private int timeoutSeconds = 0;
-
-    private int maxInconsistencyLogLength = 65536; // 64KB
-
-    // used to associate inconsistencies with the service in the logs
-    private final String implementationName;
 
     public EntityIdStore getEntityIdStore() {
         return entityIdStore;
@@ -80,91 +56,11 @@ public class DAOFacadeBase<D> {
     }
 
     public DAOFacadeBase(D legacyDAO, D lightblueDAO) {
-        super();
         this.legacyDAO = legacyDAO;
         this.lightblueDAO = lightblueDAO;
         setEntityIdStore(new EntityIdStoreImpl(this.getClass())); // this.getClass() will point at superclass
-        this.implementationName = this.getClass().getSimpleName();
+        super.implementationName = this.getClass().getSimpleName();
         log.info("Initialized facade for "+implementationName);
-    }
-
-    private Map<Class<?>,ModelMixIn> findModelMixInMappings() {
-        if  (modelMixIns==null) {
-            Reflections reflections = new Reflections("");
-            Set<Class<?>> classes = reflections.getTypesAnnotatedWith(ModelMixIn.class);
-            modelMixIns = new HashMap<>();
-            for (Class<?> clazz : classes) {
-                modelMixIns.put(clazz, clazz.getAnnotation(ModelMixIn.class));
-            }
-        }
-        return modelMixIns;
-    }
-
-    private ObjectWriter getObjectWriter(String methodName) {
-        ObjectMapper mapper = new ObjectMapper();
-        for (Map.Entry<Class<?>, ModelMixIn> entry : findModelMixInMappings().entrySet()) {
-            if (methodName==null || entry.getValue().includeMethods().length==0 || Arrays.asList(entry.getValue().includeMethods()).contains(methodName)) {
-                mapper.addMixInAnnotations(entry.getValue().clazz(), entry.getKey());
-            }
-        }
-        return mapper.writer();
-    }
-
-    // for unit testing
-    public boolean checkConsistency(Object o1, Object o2) {
-        return checkConsistency(o1, o2, null, null);
-    }
-
-    /*
-     * Log message < MAX_INCONSISTENCY_LOG_LENGTH to server.log.
-     * Log message > MAX_INCONSISTENCY_LOG_LENGTH and diff <= MAX_INCONSISTENCY_LOG_LENGTH, log diff to server.log.
-     * Otherwise log method name and parameters to server.log and full message to inconsistency.log.
-     */
-    private void logInconsistency(String callToLogInCaseOfInconsistency, String legacyJson, String lightblueJson, String diff) {
-        String logMessage = String.format("Inconsistency found in %s.%s - diff: %s legacyJson: %s, lightblueJson: %s", implementationName, callToLogInCaseOfInconsistency, diff, legacyJson, lightblueJson);
-        if (logMessage.length()<=maxInconsistencyLogLength) {
-            log.warn(logMessage);
-        } else if (diff!=null&&diff.length()<=maxInconsistencyLogLength) {
-            log.warn(String.format("Inconsistency found in %s.%s - diff: %s", implementationName, callToLogInCaseOfInconsistency, diff));
-        } else {
-            log.warn(String.format("Inconsistency found in %s.%s - payload and diff is greater than %d bytes!", implementationName, callToLogInCaseOfInconsistency, maxInconsistencyLogLength));
-            logInconsisteny.debug(logMessage); // logging at debug level since everything >= info would also land in server.log
-        }
-    }
-
-    public boolean checkConsistency(final Object o1, final Object o2, String methodName, String callToLogInCaseOfInconsistency) {
-        if (o1==null&&o2==null) {
-            return true;
-        }
-
-        String legacyJson=null;
-        String lightblueJson=null;
-        try {
-            long t1 = System.currentTimeMillis();
-            legacyJson = getObjectWriter(methodName).writeValueAsString(o1);
-            lightblueJson = getObjectWriter(methodName).writeValueAsString(o2);
-
-            JSONCompareResult result = JSONCompare.compareJSON(legacyJson, lightblueJson, JSONCompareMode.LENIENT);
-            long t2 = System.currentTimeMillis();
-
-            if (log.isDebugEnabled()) {
-                log.debug("Consistency check took: " + (t2-t1)+" ms");
-                log.debug("Consistency check passed: "+ result.passed());
-            }
-            if (!result.passed()) {
-                logInconsistency(callToLogInCaseOfInconsistency, legacyJson, lightblueJson, result.getMessage().replaceAll("\n", ","));
-            }
-            return result.passed();
-        } catch (JSONException e) {
-            if (o1!=null&&o1.equals(o2)) {
-                return true;
-            } else {
-                logInconsistency(callToLogInCaseOfInconsistency, legacyJson, lightblueJson, null);
-            }
-        } catch (JsonProcessingException e) {
-            log.error("Consistency check failed! Invalid JSON. ", e);
-        }
-        return false;
     }
 
     private ListeningExecutorService createExecutor() {

--- a/facade/src/main/java/com/redhat/lightblue/migrator/facade/DAOFacadeBase.java
+++ b/facade/src/main/java/com/redhat/lightblue/migrator/facade/DAOFacadeBase.java
@@ -49,6 +49,7 @@ import com.redhat.lightblue.migrator.features.TogglzRandomUsername;
 public class DAOFacadeBase<D> {
 
     private static final Logger log = LoggerFactory.getLogger(DAOFacadeBase.class);
+    private static final Logger logInconsisteny = LoggerFactory.getLogger("Inconsistency");
 
     protected final D legacyDAO, lightblueDAO;
 
@@ -57,6 +58,8 @@ public class DAOFacadeBase<D> {
     private Map<Class<?>,ModelMixIn> modelMixIns;
 
     private int timeoutSeconds = 0;
+
+    private int maxInconsistencyLogLength = 65536; // 64KB
 
     // used to associate inconsistencies with the service in the logs
     private final String implementationName;
@@ -107,9 +110,26 @@ public class DAOFacadeBase<D> {
         return mapper.writer();
     }
 
-    // user for unit testing
+    // for unit testing
     public boolean checkConsistency(Object o1, Object o2) {
         return checkConsistency(o1, o2, null, null);
+    }
+
+    /*
+     * Log message < MAX_INCONSISTENCY_LOG_LENGTH to server.log.
+     * Log message > MAX_INCONSISTENCY_LOG_LENGTH and diff <= MAX_INCONSISTENCY_LOG_LENGTH, log diff to server.log.
+     * Otherwise log method name and parameters to server.log and full message to inconsistency.log.
+     */
+    private void logInconsistency(String callToLogInCaseOfInconsistency, String legacyJson, String lightblueJson, String diff) {
+        String logMessage = String.format("Inconsistency found in %s.%s - diff: %s legacyJson: %s, lightblueJson: %s", implementationName, callToLogInCaseOfInconsistency, diff, legacyJson, lightblueJson);
+        if (logMessage.length()<=maxInconsistencyLogLength) {
+            log.warn(logMessage);
+        } else if (diff!=null&&diff.length()<=maxInconsistencyLogLength) {
+            log.warn(String.format("Inconsistency found in %s.%s - diff: %s", implementationName, callToLogInCaseOfInconsistency, diff));
+        } else {
+            log.warn(String.format("Inconsistency found in %s.%s - payload and diff is greater than %d bytes!", implementationName, callToLogInCaseOfInconsistency, maxInconsistencyLogLength));
+            logInconsisteny.debug(logMessage); // logging at debug level since everything >= info would also land in server.log
+        }
     }
 
     public boolean checkConsistency(final Object o1, final Object o2, String methodName, String callToLogInCaseOfInconsistency) {
@@ -132,14 +152,14 @@ public class DAOFacadeBase<D> {
                 log.debug("Consistency check passed: "+ result.passed());
             }
             if (!result.passed()) {
-                log.warn(String.format("Inconsistency found in %s.%s:%s legacyJson: %s, lightblueJson: %s", implementationName, callToLogInCaseOfInconsistency, result.getMessage().replaceAll("\n", ","), legacyJson, lightblueJson));
+                logInconsistency(callToLogInCaseOfInconsistency, legacyJson, lightblueJson, result.getMessage().replaceAll("\n", ","));
             }
             return result.passed();
         } catch (JSONException e) {
             if (o1!=null&&o1.equals(o2)) {
                 return true;
             } else {
-                log.warn(String.format("Inconsistency found in %s.%s:%s legacyJson: %s, lightblueJson: %s", implementationName, callToLogInCaseOfInconsistency, methodName, legacyJson, lightblueJson));
+                logInconsistency(callToLogInCaseOfInconsistency, legacyJson, lightblueJson, null);
             }
         } catch (JsonProcessingException e) {
             log.error("Consistency check failed! Invalid JSON. ", e);
@@ -540,8 +560,15 @@ public class DAOFacadeBase<D> {
         this.timeoutSeconds = timeoutSeconds;
     }
 
+    public void setMaxInconsistencyLogLength(int length) {
+        this.maxInconsistencyLogLength = length;
+    }
+
+    public int getMaxInconsistencyLogLength() {
+        return maxInconsistencyLogLength;
+    }
+
     public D getLegacyDAO() {
         return legacyDAO;
     }
-
 }

--- a/facade/src/main/java/com/redhat/lightblue/migrator/facade/ServiceFacade.java
+++ b/facade/src/main/java/com/redhat/lightblue/migrator/facade/ServiceFacade.java
@@ -5,28 +5,15 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import org.json.JSONException;
-import org.reflections.Reflections;
-import org.skyscreamer.jsonassert.JSONCompare;
-import org.skyscreamer.jsonassert.JSONCompareMode;
-import org.skyscreamer.jsonassert.JSONCompareResult;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectWriter;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
@@ -45,10 +32,7 @@ import com.redhat.lightblue.migrator.features.TogglzRandomUsername;
  *
  */
 @SuppressWarnings("all")
-public class ServiceFacade<D> implements SharedStoreSetter {
-
-    private static final Logger log = LoggerFactory.getLogger(ServiceFacade.class);
-    private static final Logger logInconsisteny = LoggerFactory.getLogger("Inconsistency");
+public class ServiceFacade<D> extends AbstractServiceFacade implements SharedStoreSetter {
 
     protected final D legacySvc, lightblueSvc;
 
@@ -57,11 +41,6 @@ public class ServiceFacade<D> implements SharedStoreSetter {
     private Map<Class<?>,ModelMixIn> modelMixIns;
 
     private int timeoutSeconds = 0;
-
-    private int maxInconsistencyLogLength = 65536; // 64KB
-
-    // used to associate inconsistencies with the service in the logs
-    private final String implementationName;
 
     public SharedStore getSharedStore() {
         return sharedStore;
@@ -79,96 +58,8 @@ public class ServiceFacade<D> implements SharedStoreSetter {
         this.legacySvc = legacySvc;
         this.lightblueSvc = lightblueSvc;
         setSharedStore(new SharedStoreImpl(serviceClass));
-        this.implementationName = serviceClass.getSimpleName();
+        super.implementationName = this.getClass().getSimpleName();
         log.info("Initialized facade for "+implementationName);
-    }
-
-    private Map<Class<?>,ModelMixIn> findModelMixInMappings() {
-        if  (modelMixIns==null) {
-            Reflections reflections = new Reflections("");
-            Set<Class<?>> classes = reflections.getTypesAnnotatedWith(ModelMixIn.class);
-            modelMixIns = new HashMap<>();
-            for (Class<?> clazz : classes) {
-                modelMixIns.put(clazz, clazz.getAnnotation(ModelMixIn.class));
-            }
-        }
-        return modelMixIns;
-    }
-
-    private ObjectWriter getObjectWriter(String methodName) {
-        ObjectMapper mapper = new ObjectMapper();
-        for (Map.Entry<Class<?>, ModelMixIn> entry : findModelMixInMappings().entrySet()) {
-            if (methodName==null || entry.getValue().includeMethods().length==0 || Arrays.asList(entry.getValue().includeMethods()).contains(methodName)) {
-                mapper.addMixInAnnotations(entry.getValue().clazz(), entry.getKey());
-            }
-        }
-        return mapper.writer();
-    }
-
-    // for unit testing
-    public boolean checkConsistency(Object o1, Object o2) {
-        return checkConsistency(o1, o2, null, null);
-    }
-
-    /*
-     * Log message < MAX_INCONSISTENCY_LOG_LENGTH to server.log.
-     * Log message > MAX_INCONSISTENCY_LOG_LENGTH and diff <= MAX_INCONSISTENCY_LOG_LENGTH, log diff to server.log.
-     * Otherwise log method name and parameters to server.log and full message to inconsistency.log.
-     */
-    private void logInconsistency(String callToLogInCaseOfInconsistency, String legacyJson, String lightblueJson, String diff) {
-        String logMessage = String.format("Inconsistency found in %s.%s - diff: %s legacyJson: %s, lightblueJson: %s", implementationName, callToLogInCaseOfInconsistency, diff, legacyJson, lightblueJson);
-        if (logMessage.length()<=maxInconsistencyLogLength) {
-            log.warn(logMessage);
-        } else if (diff!=null&&diff.length()<=maxInconsistencyLogLength) {
-            log.warn(String.format("Inconsistency found in %s.%s - diff: %s", implementationName, callToLogInCaseOfInconsistency, diff));
-        } else {
-            log.warn(String.format("Inconsistency found in %s.%s - payload and diff is greater than %d bytes!", implementationName, callToLogInCaseOfInconsistency, maxInconsistencyLogLength));
-            logInconsisteny.debug(logMessage); // logging at debug level since everything >= info would also land in server.log
-        }
-    }
-
-    /**
-     * Check that objects are equal using org.skyscreamer.jsonassert library.
-     *
-     * @param o1                              object returned from legacy call
-     * @param o2                              object returned from lightblue call
-     * @param methodName                      the method name
-     * @param callToLogInCaseOfInconsistency  the call including parameters
-     * @return
-     */
-    public boolean checkConsistency(final Object o1, final Object o2, String methodName, String callToLogInCaseOfInconsistency) {
-        if (o1==null&&o2==null) {
-            return true;
-        }
-
-        String legacyJson=null;
-        String lightblueJson=null;
-        try {
-            long t1 = System.currentTimeMillis();
-            legacyJson = getObjectWriter(methodName).writeValueAsString(o1);
-            lightblueJson = getObjectWriter(methodName).writeValueAsString(o2);
-
-            JSONCompareResult result = JSONCompare.compareJSON(legacyJson, lightblueJson, JSONCompareMode.LENIENT);
-            long t2 = System.currentTimeMillis();
-
-            if (log.isDebugEnabled()) {
-                log.debug("Consistency check took: " + (t2-t1)+" ms");
-                log.debug("Consistency check passed: "+ result.passed());
-            }
-            if (!result.passed()) {
-                logInconsistency(callToLogInCaseOfInconsistency, legacyJson, lightblueJson, result.getMessage().replaceAll("\n", ","));
-            }
-            return result.passed();
-        } catch (JSONException e) {
-            if (o1!=null&&o1.equals(o2)) {
-                return true;
-            } else {
-                logInconsistency(callToLogInCaseOfInconsistency, legacyJson, lightblueJson, null);
-            }
-        } catch (JsonProcessingException e) {
-            log.error("Consistency check failed! Invalid JSON. ", e);
-        }
-        return false;
     }
 
     private ListeningExecutorService createExecutor() {
@@ -417,16 +308,7 @@ public class ServiceFacade<D> implements SharedStoreSetter {
         this.timeoutSeconds = timeoutSeconds;
     }
 
-    public void setMaxInconsistencyLogLength(int length) {
-        this.maxInconsistencyLogLength = length;
-    }
-
-    public int getMaxInconsistencyLogLength() {
-        return maxInconsistencyLogLength;
-    }
-
     public D getLegacySvc() {
         return legacySvc;
     }
-
 }

--- a/facade/src/main/java/com/redhat/lightblue/migrator/facade/ServiceFacade.java
+++ b/facade/src/main/java/com/redhat/lightblue/migrator/facade/ServiceFacade.java
@@ -132,7 +132,7 @@ public class ServiceFacade<D> implements SharedStoreSetter {
      *
      * @param o1                              object returned from legacy call
      * @param o2                              object returned from lightblue call
-     * @param methodName the                  method name
+     * @param methodName                      the method name
      * @param callToLogInCaseOfInconsistency  the call including parameters
      * @return
      */

--- a/facade/src/test/java/com/redhat/lightblue/migrator/facade/ConsistencyCheckTest.java
+++ b/facade/src/test/java/com/redhat/lightblue/migrator/facade/ConsistencyCheckTest.java
@@ -32,11 +32,11 @@ public class ConsistencyCheckTest {
 
     CountryDAO legacyDAO = Mockito.mock(CountryDAO.class, Mockito.withSettings().extraInterfaces(SharedStoreSetter.class));
     CountryDAO lightblueDAO = Mockito.mock(CountryDAO.class, Mockito.withSettings().extraInterfaces(SharedStoreSetter.class));
-    ServiceFacade<CountryDAO> daoFacadeExample;
+    ConsistencyChecker consistencyChecker;
 
     @Before
     public void setup() throws InstantiationException, IllegalAccessException {
-        daoFacadeExample = new ServiceFacade<CountryDAO>(legacyDAO, (CountryDAO)lightblueDAO, CountryDAO.class);
+        consistencyChecker = new ConsistencyChecker(CountryDAO.class.getSimpleName());
     }
 
     @Test
@@ -47,23 +47,23 @@ public class ConsistencyCheckTest {
         Country pl2 = new Country(1l, "PL");
         pl2.setName("Poland2");
 
-        Assert.assertTrue(daoFacadeExample.checkConsistency(pl1, pl2));
+        Assert.assertTrue(consistencyChecker.checkConsistency(pl1, pl2));
     }
 
     @Test
     public void testConsistencyWithNull() {
-        Assert.assertTrue(daoFacadeExample.checkConsistency(null, null));
-        Assert.assertFalse(daoFacadeExample.checkConsistency(null, new Country()));
-        Assert.assertFalse(daoFacadeExample.checkConsistency(new Country(), null));
+        Assert.assertTrue(consistencyChecker.checkConsistency(null, null));
+        Assert.assertFalse(consistencyChecker.checkConsistency(null, new Country()));
+        Assert.assertFalse(consistencyChecker.checkConsistency(new Country(), null));
 
         Country c1 = new Country(1l, null);
         Country c2 = new Country(1l, null);
 
-        Assert.assertTrue(daoFacadeExample.checkConsistency(c1, c2));
+        Assert.assertTrue(consistencyChecker.checkConsistency(c1, c2));
 
-        Assert.assertTrue(daoFacadeExample.checkConsistency(null, null));
-        Assert.assertFalse(daoFacadeExample.checkConsistency(c1, null));
-        Assert.assertFalse(daoFacadeExample.checkConsistency(null, c1));
+        Assert.assertTrue(consistencyChecker.checkConsistency(null, null));
+        Assert.assertFalse(consistencyChecker.checkConsistency(c1, null));
+        Assert.assertFalse(consistencyChecker.checkConsistency(null, c1));
     }
 
     @Test
@@ -71,7 +71,7 @@ public class ConsistencyCheckTest {
         Country pl1 = new Country(1l, "PL");
         Country pl2 = new Country(2l, "PL");
 
-        Assert.assertFalse(daoFacadeExample.checkConsistency(pl1, pl2));
+        Assert.assertFalse(consistencyChecker.checkConsistency(pl1, pl2));
     }
 
     @Test
@@ -79,7 +79,7 @@ public class ConsistencyCheckTest {
         Country[] cArr1 = new Country[] { new Country(1l, "PL"), new Country(2l, "CA")};
         Country[] cArr2 = new Country[] { new Country(1l, "PL"), new Country(2l, "CA")};
 
-        Assert.assertTrue(daoFacadeExample.checkConsistency(Arrays.asList(cArr1), Arrays.asList(cArr2)));
+        Assert.assertTrue(consistencyChecker.checkConsistency(Arrays.asList(cArr1), Arrays.asList(cArr2)));
     }
 
     @Test
@@ -87,12 +87,12 @@ public class ConsistencyCheckTest {
         Country[] cArr1 = new Country[] { new Country(1l, "PL"), new Country(2l, "CA")};
         Country[] cArr2 = new Country[] { new Country(3l, "PL"), new Country(2l, "CA")};
 
-        Assert.assertFalse(daoFacadeExample.checkConsistency(Arrays.asList(cArr1), Arrays.asList(cArr2)));
+        Assert.assertFalse(consistencyChecker.checkConsistency(Arrays.asList(cArr1), Arrays.asList(cArr2)));
 
         Country[] cArr3 = new Country[] { new Country(2l, "CA"), new Country(1l, "PL")};
         Country[] cArr4 = new Country[] { new Country(1l, "PL"), new Country(2l, "CA")};
 
-        Assert.assertTrue(daoFacadeExample.checkConsistency(Arrays.asList(cArr3), Arrays.asList(cArr4)));
+        Assert.assertTrue(consistencyChecker.checkConsistency(Arrays.asList(cArr3), Arrays.asList(cArr4)));
     }
 
     @Test
@@ -100,7 +100,7 @@ public class ConsistencyCheckTest {
         Country[] cArr1 = new Country[] { new Country(1l, "PL"), new Country(2l, "CA")};
         Country[] cArr2 = new Country[] { new Country(1l, "PL"), new Country(2l, "CA")};
 
-        Assert.assertTrue(daoFacadeExample.checkConsistency(cArr1, cArr2));
+        Assert.assertTrue(consistencyChecker.checkConsistency(cArr1, cArr2));
     }
 
     @Test
@@ -108,12 +108,12 @@ public class ConsistencyCheckTest {
         Country[] cArr1 = new Country[] { new Country(1l, "PL"), new Country(2l, "CA")};
         Country[] cArr2 = new Country[] { new Country(3l, "PL"), new Country(2l, "CA")};
 
-        Assert.assertFalse(daoFacadeExample.checkConsistency(cArr1, cArr2));
+        Assert.assertFalse(consistencyChecker.checkConsistency(cArr1, cArr2));
 
         Country[] cArr3 = new Country[] { new Country(2l, "CA"), new Country(1l, "PL")};
         Country[] cArr4 = new Country[] { new Country(1l, "PL"), new Country(2l, "CA")};
 
-        Assert.assertTrue(daoFacadeExample.checkConsistency(cArr3, cArr4));
+        Assert.assertTrue(consistencyChecker.checkConsistency(cArr3, cArr4));
     }
 
     @Test
@@ -123,7 +123,7 @@ public class ConsistencyCheckTest {
         Country pl2 = new ExtendedCountry(1l, "PL");
         pl2.setName("Poland2");
 
-        Assert.assertTrue(daoFacadeExample.checkConsistency(pl1, pl2));
+        Assert.assertTrue(consistencyChecker.checkConsistency(pl1, pl2));
     }
 
     @Test
@@ -131,10 +131,10 @@ public class ConsistencyCheckTest {
         Country pl1 = new ExtendedCountry(1l, "PL");
         Country pl2 = new Country(1l, "PL");
 
-        Assert.assertFalse(daoFacadeExample.checkConsistency(pl1, pl2));
+        Assert.assertFalse(consistencyChecker.checkConsistency(pl1, pl2));
 
         // We are using compare mode = Lenient, which means object 2 can have additional data
-        Assert.assertTrue(daoFacadeExample.checkConsistency(pl2, pl1));
+        Assert.assertTrue(consistencyChecker.checkConsistency(pl2, pl1));
     }
 
     @Test
@@ -142,7 +142,7 @@ public class ConsistencyCheckTest {
         Country pl1 = new VeryExtendedCountry(1l, "PL", "foo");
         Country pl2 = new VeryExtendedCountry(1l, "PL", "bar");
 
-        Assert.assertTrue(daoFacadeExample.checkConsistency(pl1, pl2));
+        Assert.assertTrue(consistencyChecker.checkConsistency(pl1, pl2));
     }
 
     @Test
@@ -153,9 +153,9 @@ public class ConsistencyCheckTest {
         Country pl1 = new CountryInCountry(1l, "PL", inner1);
         Country pl2 = new CountryInCountry(1l, "PL", inner2);
 
-        Assert.assertFalse(daoFacadeExample.checkConsistency(pl1, pl2));
+        Assert.assertFalse(consistencyChecker.checkConsistency(pl1, pl2));
 
-        Assert.assertTrue(daoFacadeExample.checkConsistency(pl1, new CountryInCountry(1l, "PL", new Country(2l, "CA"))));
+        Assert.assertTrue(consistencyChecker.checkConsistency(pl1, new CountryInCountry(1l, "PL", new Country(2l, "CA"))));
     }
 
     @Test
@@ -166,8 +166,8 @@ public class ConsistencyCheckTest {
         CountryWithDate pl1 = new CountryWithDate(date);
         CountryWithDate pl2 = new CountryWithDate(timestamp);
 
-        Assert.assertTrue(daoFacadeExample.checkConsistency(pl1, pl2));
-        Assert.assertTrue(daoFacadeExample.checkConsistency(pl2, pl1));
+        Assert.assertTrue(consistencyChecker.checkConsistency(pl1, pl2));
+        Assert.assertTrue(consistencyChecker.checkConsistency(pl2, pl1));
     }
 
     @Test
@@ -181,8 +181,8 @@ public class ConsistencyCheckTest {
         CountryWithDate pl1 = new CountryWithDate(date);
         CountryWithDate pl2 = new CountryWithDate(timestamp);
 
-        Assert.assertTrue(daoFacadeExample.checkConsistency(pl1, pl2));
-        Assert.assertTrue(daoFacadeExample.checkConsistency(pl2, pl1));
+        Assert.assertTrue(consistencyChecker.checkConsistency(pl1, pl2));
+        Assert.assertTrue(consistencyChecker.checkConsistency(pl2, pl1));
     }
 
     @Test
@@ -193,35 +193,35 @@ public class ConsistencyCheckTest {
         CountryWithBigDecimal pl1 = new CountryWithBigDecimal(value1);
         CountryWithBigDecimal pl2 = new CountryWithBigDecimal(value2);
 
-        Assert.assertTrue(daoFacadeExample.checkConsistency(pl1, pl2));
-        Assert.assertTrue(daoFacadeExample.checkConsistency(pl2, pl1));
+        Assert.assertTrue(consistencyChecker.checkConsistency(pl1, pl2));
+        Assert.assertTrue(consistencyChecker.checkConsistency(pl2, pl1));
     }
 
     @Test
     public void testWithMethodInclusion() {
         Person p1 = new Person("John", "Doe", 35, "British");
         Person p2 = new Person("John", "Doe", 35, "German");
-        Assert.assertTrue(daoFacadeExample.checkConsistency(p1, p2, "getPerson", null));
-        Assert.assertFalse(daoFacadeExample.checkConsistency(p1, p2, "getPerson2", null));
+        Assert.assertTrue(consistencyChecker.checkConsistency(p1, p2, "getPerson", null));
+        Assert.assertFalse(consistencyChecker.checkConsistency(p1, p2, "getPerson2", null));
 
         p1 = new Person("John", "Doe", 35, "British");
         p2 = new Person("John", "Doe", 30, "British");
-        Assert.assertFalse(daoFacadeExample.checkConsistency(p1, p2, "getPerson", null));
-        Assert.assertTrue(daoFacadeExample.checkConsistency(p1, p2, "getPerson2", null));
+        Assert.assertFalse(consistencyChecker.checkConsistency(p1, p2, "getPerson", null));
+        Assert.assertTrue(consistencyChecker.checkConsistency(p1, p2, "getPerson2", null));
     }
 
     @Test
     public void testWithSimpleObjects() throws InterruptedException {
-        Assert.assertTrue(daoFacadeExample.checkConsistency("Test", "Test", "savePerson", null));
-        Assert.assertFalse(daoFacadeExample.checkConsistency("Test", "Test2", "savePerson", null));
-        Assert.assertTrue(daoFacadeExample.checkConsistency(true, true, "savePerson", null));
-        Assert.assertFalse(daoFacadeExample.checkConsistency(true, false, "savePerson", null));
-        Assert.assertTrue(daoFacadeExample.checkConsistency(100, 100, "savePerson", null));
-        Assert.assertFalse(daoFacadeExample.checkConsistency(100, 101, "savePerson", null));
+        Assert.assertTrue(consistencyChecker.checkConsistency("Test", "Test", "savePerson", null));
+        Assert.assertFalse(consistencyChecker.checkConsistency("Test", "Test2", "savePerson", null));
+        Assert.assertTrue(consistencyChecker.checkConsistency(true, true, "savePerson", null));
+        Assert.assertFalse(consistencyChecker.checkConsistency(true, false, "savePerson", null));
+        Assert.assertTrue(consistencyChecker.checkConsistency(100, 100, "savePerson", null));
+        Assert.assertFalse(consistencyChecker.checkConsistency(100, 101, "savePerson", null));
         Date d = new Date();
-        Assert.assertTrue(daoFacadeExample.checkConsistency(d, d, "savePerson", null));
+        Assert.assertTrue(consistencyChecker.checkConsistency(d, d, "savePerson", null));
         Thread.sleep(10); // make sure dates below are inconsistent
-        Assert.assertFalse(daoFacadeExample.checkConsistency(d, new Date(), "savePerson", null));
+        Assert.assertFalse(consistencyChecker.checkConsistency(d, new Date(), "savePerson", null));
 
     }
 }

--- a/facade/src/test/java/com/redhat/lightblue/migrator/facade/ConsistencyLoggerTest.java
+++ b/facade/src/test/java/com/redhat/lightblue/migrator/facade/ConsistencyLoggerTest.java
@@ -1,0 +1,158 @@
+package com.redhat.lightblue.migrator.facade;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.slf4j.Logger;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ConsistencyLoggerTest {
+
+    @Mock
+    private Logger log;
+
+    @Mock
+    private Logger inconsistencyLog;
+
+    @InjectMocks
+    private ConsistencyChecker consistencyChecker = new ConsistencyChecker(CountryDAO.class.getSimpleName());
+
+    @Captor
+    private ArgumentCaptor<String> logStmt;
+
+    @Captor
+    private ArgumentCaptor<String> inconsistencyLogStmt;
+
+    @Before
+    public void setup() throws InstantiationException, IllegalAccessException {
+        initMocks(this);
+    }
+
+    private List<String> getDummyMessage(String prefix, int maxBytes) throws JsonProcessingException {
+
+        int count = maxBytes / 12; // one country is ~12 bytes when its transformed to json
+
+        List<String> list = new ArrayList<>();
+        for (long i=0;i<count;i++) {
+            list.add(String.valueOf(prefix+(i+10000)));
+        }
+
+        return list;
+    }
+
+    @Test
+    public void logTest_logResponsesEnabled_logLessThanLogLimit() throws Exception {
+
+        // set maxLogLength to simplify unit testing
+        consistencyChecker.setMaxInconsistencyLogLength(175);
+
+        // enable response data logging
+        consistencyChecker.setLogResponseDataEnabled(true);
+
+        List<String> legacy = getDummyMessage("Test", 24);
+        List<String> lightblue = getDummyMessage("Test", 12);
+        boolean result = consistencyChecker.checkConsistency(legacy, lightblue, "testMethod", "testMethod(param1, param2)");
+        assertFalse(result);
+        verify(log).warn(logStmt.capture());
+        assertEquals("Inconsistency found in CountryDAO.testMethod(param1, param2) - diff: []: Expected 2 values but got 1 - legacyJson: [\"Test10000\",\"Test10001\"], lightblueJson: [\"Test10000\"]", logStmt.getValue());
+        verify(inconsistencyLog, never()).debug(anyString());
+    }
+
+    @Test
+    public void logTest_logResponsesEnabled_logGreaterThanLogLimit() throws Exception {
+
+        // set maxLogLength to simplify unit testing
+        consistencyChecker.setMaxInconsistencyLogLength(175);
+
+        // enable response data logging
+        consistencyChecker.setLogResponseDataEnabled(true);
+
+        List<String> legacy = getDummyMessage("Test", 36);
+        List<String> lightblue = getDummyMessage("Test", 24);
+        boolean result = consistencyChecker.checkConsistency(legacy, lightblue, "testMethod", "testMethod(param1, param2)");
+        assertFalse(result);
+        verify(log).warn(logStmt.capture());
+        assertEquals("Inconsistency found in CountryDAO.testMethod(param1, param2) - diff: []: Expected 3 values but got 2", logStmt.getValue());
+        verify(inconsistencyLog).debug(inconsistencyLogStmt.capture());
+        assertEquals("Inconsistency found in CountryDAO.testMethod(param1, param2) - diff: []: Expected 3 values but got 2 - legacyJson: [\"Test10000\",\"Test10001\",\"Test10002\"], lightblueJson: [\"Test10000\",\"Test10001\"]", inconsistencyLogStmt.getValue());
+    }
+
+    @Test
+    public void logTest_logResponsesEnabled_diffGreaterThanLogLimit() throws Exception {
+
+        // set maxLogLength to simplify unit testing
+        consistencyChecker.setMaxInconsistencyLogLength(175);
+
+        // enable response data logging
+        consistencyChecker.setLogResponseDataEnabled(true);
+
+        List<String> legacy = getDummyMessage("Test", 40);
+        List<String> lightblue = getDummyMessage("Fooo", 40);
+        boolean result = consistencyChecker.checkConsistency(legacy, lightblue, "testMethod", "testMethod(param1, param2)");
+        assertFalse(result);
+        verify(log).warn(logStmt.capture());
+        assertEquals("Inconsistency found in CountryDAO.testMethod(param1, param2) - payload and diff is greater than 175 bytes!", logStmt.getValue());
+        verify(inconsistencyLog).debug(inconsistencyLogStmt.capture());
+        assertTrue(inconsistencyLogStmt.getValue().contains("diff"));
+        assertTrue(inconsistencyLogStmt.getValue().contains("legacyJson"));
+        assertTrue(inconsistencyLogStmt.getValue().contains("lightblueJson"));
+    }
+
+    @Test
+    public void logTest_logResponsesDisabled_logLessThanLogLimit() throws Exception {
+
+        // set maxLogLength to simplify unit testing
+        consistencyChecker.setMaxInconsistencyLogLength(175);
+
+        // disable response data logging
+        consistencyChecker.setLogResponseDataEnabled(false);
+
+        List<String> legacy = getDummyMessage("Test", 24);
+        List<String> lightblue = getDummyMessage("Test", 12);
+        boolean result = consistencyChecker.checkConsistency(legacy, lightblue, "testMethod", "testMethod(param1, param2)");
+        assertFalse(result);
+        verify(log).warn(logStmt.capture());
+        assertEquals("Inconsistency found in CountryDAO.testMethod(param1, param2) - diff: []: Expected 2 values but got 1", logStmt.getValue());
+        verify(inconsistencyLog).debug(inconsistencyLogStmt.capture());
+        assertEquals("Inconsistency found in CountryDAO.testMethod(param1, param2) - diff: []: Expected 2 values but got 1 - legacyJson: [\"Test10000\",\"Test10001\"], lightblueJson: [\"Test10000\"]", inconsistencyLogStmt.getValue());
+    }
+
+    @Test
+    public void logTest_logResponsesDisabled_diffGreaterThanLogLimit() throws Exception {
+
+        // set maxLogLength to simplify unit testing
+        consistencyChecker.setMaxInconsistencyLogLength(175);
+
+        // disable response data logging
+        consistencyChecker.setLogResponseDataEnabled(false);
+
+        List<String> legacy = getDummyMessage("Test", 40);
+        List<String> lightblue = getDummyMessage("Fooo", 40);
+        boolean result = consistencyChecker.checkConsistency(legacy, lightblue, "testMethod", "testMethod(param1, param2)");
+        assertFalse(result);
+        verify(log).warn(logStmt.capture());
+        assertEquals("Inconsistency found in CountryDAO.testMethod(param1, param2) - diff is greater than 175 bytes!", logStmt.getValue());
+        verify(inconsistencyLog).debug(inconsistencyLogStmt.capture());
+        assertTrue(inconsistencyLogStmt.getValue().contains("diff"));
+        assertTrue(inconsistencyLogStmt.getValue().contains("legacyJson"));
+        assertTrue(inconsistencyLogStmt.getValue().contains("lightblueJson"));
+    }
+}

--- a/facade/src/test/java/com/redhat/lightblue/migrator/facade/DAOFacadeTest.java
+++ b/facade/src/test/java/com/redhat/lightblue/migrator/facade/DAOFacadeTest.java
@@ -29,11 +29,16 @@ public class DAOFacadeTest {
     @Mock CountryDAO legacyDAO;
     @Mock CountryDAOLightblue lightblueDAO;
     CountryDAO facade;
+
     DAOFacadeExample daoFacadeExample;
+    ConsistencyChecker consistencyChecker;
 
     @Before
     public void setup() {
         daoFacadeExample = Mockito.spy(new DAOFacadeExample(legacyDAO, lightblueDAO));
+        consistencyChecker = Mockito.spy(new ConsistencyChecker(CountryDAO.class.getSimpleName()));
+        daoFacadeExample.setConsistencyChecker(consistencyChecker);
+
         facade = daoFacadeExample;
         Mockito.verify(lightblueDAO).setEntityIdStore((daoFacadeExample).getEntityIdStore());
     }
@@ -52,7 +57,7 @@ public class DAOFacadeTest {
 
         facade.getCountry("PL");
 
-        Mockito.verify(daoFacadeExample, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString());
+        Mockito.verify(consistencyChecker, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString());
         Mockito.verifyNoMoreInteractions(lightblueDAO);
         Mockito.verify(legacyDAO).getCountry("PL");
     }
@@ -68,7 +73,7 @@ public class DAOFacadeTest {
 
         facade.getCountry("PL");
 
-        Mockito.verify(daoFacadeExample).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString());
+        Mockito.verify(consistencyChecker).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString());
         Mockito.verify(legacyDAO).getCountry("PL");
         Mockito.verify(lightblueDAO).getCountry("PL");
     }
@@ -85,7 +90,7 @@ public class DAOFacadeTest {
 
         Country returnedCountry = facade.getCountry("PL");
 
-        Mockito.verify(daoFacadeExample).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString());
+        Mockito.verify(consistencyChecker).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString());
         Mockito.verify(legacyDAO).getCountry("PL");
         Mockito.verify(lightblueDAO).getCountry("PL");
 
@@ -107,7 +112,7 @@ public class DAOFacadeTest {
 
         Country returnedCountry = facade.getCountries(ids).get(0);
 
-        Mockito.verify(daoFacadeExample).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString());
+        Mockito.verify(consistencyChecker).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString());
         Mockito.verify(legacyDAO).getCountries(ids);
         Mockito.verify(lightblueDAO).getCountries(ids);
 
@@ -121,7 +126,7 @@ public class DAOFacadeTest {
 
         facade.getCountry("PL");
 
-        Mockito.verify(daoFacadeExample, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString());
+        Mockito.verify(consistencyChecker, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString());
         Mockito.verifyZeroInteractions(legacyDAO);
         Mockito.verify(lightblueDAO).getCountry("PL");
     }
@@ -138,7 +143,7 @@ public class DAOFacadeTest {
 
         Mockito.verifyNoMoreInteractions(lightblueDAO);
         Mockito.verify(legacyDAO).updateCountry(pl);
-        Mockito.verify(daoFacadeExample, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString());
+        Mockito.verify(consistencyChecker, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString());
     }
 
     @Test
@@ -151,7 +156,7 @@ public class DAOFacadeTest {
 
         Mockito.verify(legacyDAO).updateCountry(pl);
         Mockito.verify(lightblueDAO).updateCountry(pl);
-        Mockito.verify(daoFacadeExample).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString());
+        Mockito.verify(consistencyChecker).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString());
     }
 
     @Test
@@ -168,7 +173,7 @@ public class DAOFacadeTest {
 
         Mockito.verify(legacyDAO).updateCountry(pl);
         Mockito.verify(lightblueDAO).updateCountry(pl);
-        Mockito.verify(daoFacadeExample).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString());
+        Mockito.verify(consistencyChecker).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString());
 
         // when there is a conflict, facade will return what legacy dao returned
         Assert.assertEquals(ca, updatedEntity);
@@ -184,7 +189,7 @@ public class DAOFacadeTest {
 
         Mockito.verifyZeroInteractions(legacyDAO);
         Mockito.verify(lightblueDAO).updateCountry(pl);
-        Mockito.verify(daoFacadeExample, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString());
+        Mockito.verify(consistencyChecker, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString());
     }
 
     /* insert tests */
@@ -199,7 +204,7 @@ public class DAOFacadeTest {
 
         Mockito.verifyZeroInteractions(lightblueDAO);
         Mockito.verify(legacyDAO).createCountry(pl);
-        Mockito.verify(daoFacadeExample, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString());
+        Mockito.verify(consistencyChecker, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString());
     }
 
     @Test
@@ -217,10 +222,10 @@ public class DAOFacadeTest {
 
         Mockito.verify(legacyDAO).createCountry(pl);
         Mockito.verify(lightblueDAO).createCountry(pl);
-        Mockito.verify(daoFacadeExample).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString());
+        Mockito.verify(consistencyChecker).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString());
 
         // CountryDAOLightblue should set the id. Since it's just a mock, I'm checking what's in the cache.
-        Assert.assertTrue(101l == (Long)((DAOFacadeBase)facade).getEntityIdStore().pop());
+        Assert.assertTrue(101l == ((DAOFacadeBase)facade).getEntityIdStore().pop());
     }
 
     @Test
@@ -237,10 +242,10 @@ public class DAOFacadeTest {
 
         Mockito.verify(legacyDAO).createCountry(pl);
         Mockito.verify(lightblueDAO).createCountry(pl);
-        Mockito.verify(daoFacadeExample).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString());
+        Mockito.verify(consistencyChecker).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString());
 
         // CountryDAOLightblue should set the id. Since it's just a mock, I'm checking what's in the cache.
-        Assert.assertTrue(101l == (Long) ((DAOFacadeBase) facade).getEntityIdStore().pop());
+        Assert.assertTrue(101l == ((DAOFacadeBase) facade).getEntityIdStore().pop());
 
         Assert.assertEquals(pl.getIso2Code(), "PL");
     }
@@ -259,7 +264,7 @@ public class DAOFacadeTest {
 
         Mockito.verifyZeroInteractions(legacyDAO);
         Mockito.verify(lightblueDAO).createCountry(pl);
-        Mockito.verify(daoFacadeExample, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString());
+        Mockito.verify(consistencyChecker, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString());
     }
 
     /* insert tests when method also does a read */
@@ -274,7 +279,7 @@ public class DAOFacadeTest {
 
         Mockito.verifyZeroInteractions(lightblueDAO);
         Mockito.verify(legacyDAO).createCountryIfNotExists(pl);
-        Mockito.verify(daoFacadeExample, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString());
+        Mockito.verify(consistencyChecker, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString());
     }
 
     @Test
@@ -292,10 +297,10 @@ public class DAOFacadeTest {
 
         Mockito.verify(legacyDAO).createCountryIfNotExists(pl);
         Mockito.verify(lightblueDAO).createCountryIfNotExists(pl);
-        Mockito.verify(daoFacadeExample).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString());
+        Mockito.verify(consistencyChecker).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString());
 
         // CountryDAOLightblue should set the id. Since it's just a mock, I'm checking what's in the cache.
-        Assert.assertTrue(101l == (Long)((DAOFacadeBase)facade).getEntityIdStore().pop());
+        Assert.assertTrue(101l == ((DAOFacadeBase)facade).getEntityIdStore().pop());
     }
 
     @Test
@@ -308,7 +313,7 @@ public class DAOFacadeTest {
 
         Mockito.verifyZeroInteractions(legacyDAO);
         Mockito.verify(lightblueDAO).createCountryIfNotExists(pl);
-        Mockito.verify(daoFacadeExample, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString());
+        Mockito.verify(consistencyChecker, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString());
     }
 
     /* lightblue failure tests */
@@ -467,7 +472,7 @@ public class DAOFacadeTest {
 
         Mockito.verify(lightblueDAO).createCountry(pl);
         Mockito.verify(legacyDAO).createCountry(pl);
-        Mockito.verify(daoFacadeExample).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString());
+        Mockito.verify(consistencyChecker).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString());
 
         Assert.assertEquals(pl, returnedCountry);
     }
@@ -494,7 +499,7 @@ public class DAOFacadeTest {
 
         Mockito.verify(lightblueDAO).createCountry(pl);
         Mockito.verify(legacyDAO).createCountry(pl);
-        Mockito.verify(daoFacadeExample).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString());
+        Mockito.verify(consistencyChecker).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString());
 
         Assert.assertEquals(pl, returnedCountry);
     }
@@ -521,7 +526,7 @@ public class DAOFacadeTest {
 
         Mockito.verify(lightblueDAO).createCountry(pl);
         Mockito.verify(legacyDAO).createCountry(pl);
-        Mockito.verify(daoFacadeExample, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString());
+        Mockito.verify(consistencyChecker, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString());
 
         Assert.assertEquals(pl, returnedCountry);
     }
@@ -548,7 +553,7 @@ public class DAOFacadeTest {
 
         Mockito.verify(lightblueDAO).getCountry("PL");
         Mockito.verify(legacyDAO).getCountry("PL");
-        Mockito.verify(daoFacadeExample, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString());
+        Mockito.verify(consistencyChecker, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString());
 
         Assert.assertEquals(pl, returnedCountry);
     }
@@ -575,7 +580,7 @@ public class DAOFacadeTest {
 
         Mockito.verify(lightblueDAO).updateCountry(pl);
         Mockito.verify(legacyDAO).updateCountry(pl);
-        Mockito.verify(daoFacadeExample, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString());
+        Mockito.verify(consistencyChecker, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString());
 
         Assert.assertEquals(pl, returnedCountry);
     }
@@ -665,4 +670,5 @@ public class DAOFacadeTest {
 
         Mockito.verify(legacyDAO).createCountry(pl);
     }
+
 }


### PR DESCRIPTION
Because server.log is sent to Splunk.

Logic proposal:
1. Build inconsistency log: diff, source and destination
2. If it's < 64kB, log it into server.log (no change in behavior)
3. If it's > 64kB, build new inconsistency log: diff only
4. If it's < 64kB, log it into server.log
5. If it's still > 64kB, log in server.log only where the inconsistency was found and log full inconsistency in a separate logger at debug level. We can then adjust logging configuration at the server level to log it into a separate file.