### PR TITLE
Fixing direct legacy svc invocation

### DIFF
--- a/facade/src/main/java/com/redhat/lightblue/migrator/facade/proxy/FacadeProxyFactory.java
+++ b/facade/src/main/java/com/redhat/lightblue/migrator/facade/proxy/FacadeProxyFactory.java
@@ -1,6 +1,5 @@
 package com.redhat.lightblue.migrator.facade.proxy;
 
-import java.lang.annotation.Annotation;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -79,7 +78,9 @@ public class FacadeProxyFactory {
             }
 
             log.debug("Not a facade operation, proxy passing to legacy");
-            return method.invoke(daoFacadeBase.getLegacySvc(), args);
+
+            Method legacyMethod = daoFacadeBase.getLegacySvc().getClass().getMethod(method.getName(), method.getParameterTypes());
+            return legacyMethod.invoke(daoFacadeBase.getLegacySvc(), args);
         }
 
     }

--- a/facade/src/test/java/com/redhat/lightblue/migrator/facade/ServiceFacadeTest.java
+++ b/facade/src/test/java/com/redhat/lightblue/migrator/facade/ServiceFacadeTest.java
@@ -632,8 +632,6 @@ public class ServiceFacadeTest {
             }
         });
 
-        Mockito.doThrow(new CountryException()).when(legacyDAO).getCountry("PL");
-
         try {
             countryDAOProxy.getCountry("PL");
             Assert.fail();
@@ -681,8 +679,6 @@ public class ServiceFacadeTest {
         LightblueMigrationPhase.dualReadPhase(togglzRule);
 
         Country pl = new Country("PL");
-
-        Mockito.doThrow(new CountryException()).when(legacyDAO).createCountry(pl);
 
         Mockito.when(legacyDAO.createCountry(Mockito.any(Country.class))).thenAnswer(new Answer<Country>() {
 


### PR DESCRIPTION
When using a subinterface (descendant of the interface implemented by the facaded services) to initialize the facade, direct legacy service invocations result in ```IllegalArgumentException: object is not an instance of declaring class```. This is a fix.