### PR TITLE
Clearing shared data to ensure there are no leftovers from previous failed executions

### DIFF
--- a/facade/src/main/java/com/redhat/lightblue/migrator/facade/DAOFacadeBase.java
+++ b/facade/src/main/java/com/redhat/lightblue/migrator/facade/DAOFacadeBase.java
@@ -386,6 +386,9 @@ public class DAOFacadeBase<D> {
             log.debug("Calling {}.{} ({} {})", implementationName, methodCallToString(methodName, values), "serial", "WRITE");
         TogglzRandomUsername.init();
 
+        if (entityIdStore != null)
+            entityIdStore.clear();
+
         T legacyEntity = null, lightblueEntity = null;
 
         if (LightblueMigration.shouldWriteSourceEntity()) {

--- a/facade/src/main/java/com/redhat/lightblue/migrator/facade/EntityIdStore.java
+++ b/facade/src/main/java/com/redhat/lightblue/migrator/facade/EntityIdStore.java
@@ -24,4 +24,6 @@ public interface EntityIdStore {
      */
     public void copyFromThread(long sourceThreadId);
 
+    public void clear();
+
 }

--- a/facade/src/main/java/com/redhat/lightblue/migrator/facade/EntityIdStoreImpl.java
+++ b/facade/src/main/java/com/redhat/lightblue/migrator/facade/EntityIdStoreImpl.java
@@ -54,4 +54,9 @@ public class EntityIdStoreImpl implements EntityIdStore {
         sharedStore.copyFromThread(sourceThreadId);
     }
 
+    @Override
+    public void clear() {
+        sharedStore.clear();
+    }
+
 }

--- a/facade/src/main/java/com/redhat/lightblue/migrator/facade/ServiceFacade.java
+++ b/facade/src/main/java/com/redhat/lightblue/migrator/facade/ServiceFacade.java
@@ -255,6 +255,9 @@ public class ServiceFacade<D> implements SharedStoreSetter {
 
         TogglzRandomUsername.init();
 
+        if (sharedStore != null)
+            sharedStore.clear(); // make sure no data is left from previous calls
+
         if (sharedStore != null && shouldSource(facadeOperation) && shouldDestination(facadeOperation)) {
             sharedStore.setDualMigrationPhase(true);
         } else if (sharedStore != null){

--- a/facade/src/main/java/com/redhat/lightblue/migrator/facade/sharedstore/SharedStore.java
+++ b/facade/src/main/java/com/redhat/lightblue/migrator/facade/sharedstore/SharedStore.java
@@ -38,4 +38,10 @@ public interface SharedStore {
      */
     public void setDualMigrationPhase(boolean isDualMigrationPhase);
 
+    /**
+     * Clear data for current thread.
+     *
+     */
+    public void clear();
+
 }

--- a/facade/src/main/java/com/redhat/lightblue/migrator/facade/sharedstore/SharedStoreImpl.java
+++ b/facade/src/main/java/com/redhat/lightblue/migrator/facade/sharedstore/SharedStoreImpl.java
@@ -139,4 +139,13 @@ public class SharedStoreImpl implements SharedStore {
         cache.put(new Element("isDualMigrationPhase-"+threadId, isDualMigrationPhase));
     }
 
+    @Override
+    public void clear() {
+        long threadId = Thread.currentThread().getId();
+
+        log.debug("Clearing data for "+cache.getName()+" thread="+threadId);
+        cache.remove(threadId);
+        cache.remove("isDualMigrationPhase-"+threadId);
+    }
+
 }

--- a/facade/src/test/java/com/redhat/lightblue/migrator/facade/DAOFacadeTest.java
+++ b/facade/src/test/java/com/redhat/lightblue/migrator/facade/DAOFacadeTest.java
@@ -747,4 +747,65 @@ public class DAOFacadeTest {
         Mockito.verify(legacyDAO).createCountry(pl);
     }
 
+    @Test
+    public void clearSharedStoreAfterFailure() throws CountryException {
+        LightblueMigrationPhase.dualReadPhase(togglzRule);
+
+        final Country pl = new Country("PL");
+        final Country ca = new Country("CA");
+
+        // legacyDAO creates CA Country with id=12
+        // legacyDAO creates PL Country with id=13
+        Mockito.when(legacyDAO.createCountry(Mockito.any(Country.class))).thenAnswer(new Answer<Country>() {
+
+            @Override
+            public Country answer(InvocationOnMock invocation) throws Throwable {
+                Country country = (Country)invocation.getArguments()[0];
+                if (country.getIso2Code().equals("CA")){
+                    // oracle service pushes id of a created object into shared store
+                    daoFacadeExample.getEntityIdStore().push(12l);
+                    return new Country(12l, "CA");
+                } else {
+                    // oracle service pushes id of a created object into shared store
+                    daoFacadeExample.getEntityIdStore().push(13l);
+                    return new Country(13l, "PL");
+                }
+            }
+
+        });
+
+        // lightblueDAO fails when creating CA Country
+        // lightblueDAO creates PL Country with id=13
+        Mockito.when(lightblueDAO.createCountry(Mockito.any(Country.class))).thenAnswer(new Answer<Country>() {
+
+            @Override
+            public Country answer(InvocationOnMock invocation) throws Throwable {
+                Country country = (Country)invocation.getArguments()[0];
+                if (country.getIso2Code().equals("CA")){
+                    throw new CountryException();
+                } else {
+                    return new Country(daoFacadeExample.getEntityIdStore().pop(), "PL");
+                }
+            }
+
+        });
+
+        // lightblue service operation fails and the id is not retrieved
+        facade.createCountry(ca);
+
+        // lightblue service operation succeeds, id is retrieved from shared store
+        // reusing same thread id as the previous call
+        Country returned = facade.createCountry(pl);
+
+        Assert.assertEquals((Long)13l, returned.getId());
+
+        // the id pushed into shared store during first, failed call, is cleared, expecting no inconsistency
+        Mockito.verify(consistencyChecker).checkConsistency(Mockito.eq(new Country(13l, "PL")), Mockito.eq(new Country(13l, "PL")), Mockito.anyString(), Mockito.anyString());
+
+        Mockito.verify(legacyDAO).createCountry(pl);
+        Mockito.verify(legacyDAO).createCountry(ca);
+        Mockito.verify(lightblueDAO).createCountry(pl);
+        Mockito.verify(lightblueDAO).createCountry(ca);
+    }
+
 }

--- a/facade/src/test/java/com/redhat/lightblue/migrator/facade/MethodCallStringifierTest.java
+++ b/facade/src/test/java/com/redhat/lightblue/migrator/facade/MethodCallStringifierTest.java
@@ -22,7 +22,7 @@ public class MethodCallStringifierTest {
         l.add(new Country(1l, "PL"));
         l.add(new Country(2l, "CA"));
 
-        Assert.assertEquals("blah([PL, CA], 12, string)",
+        Assert.assertEquals("blah([PL id=1, CA id=2], 12, string)",
                 ServiceFacade.methodCallToString("blah", new Object[]{l, 12, "string"}));
     }
 
@@ -48,7 +48,7 @@ public class MethodCallStringifierTest {
     public void testArrayOfObjects() {
         Country[] arr = new Country[]{new Country(1l, "PL"), new Country(2l, "CA")};
 
-        Assert.assertEquals("blah([PL, CA], 12, string)",
+        Assert.assertEquals("blah([PL id=1, CA id=2], 12, string)",
                 ServiceFacade.methodCallToString("blah", new Object[]{arr, 12, "string"}));
     }
 

--- a/facade/src/test/java/com/redhat/lightblue/migrator/facade/model/Country.java
+++ b/facade/src/test/java/com/redhat/lightblue/migrator/facade/model/Country.java
@@ -1,5 +1,7 @@
 package com.redhat.lightblue.migrator.facade.model;
 
+import com.google.common.base.Objects;
+
 
 public class Country {
 
@@ -51,7 +53,21 @@ public class Country {
 
     @Override
     public String toString() {
-        return iso2Code;
+        return iso2Code+" id="+id;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        Country c  = (Country)obj;
+
+        if (c == null)
+            return false;
+
+        if (Objects.equal(id, c.getId()) && Objects.equal(iso2Code, c.getIso2Code()) && Objects.equal(iso3Code, c.getIso3Code())) {
+            return true;
+        }
+
+        return false;
     }
 
 }

--- a/facade/src/test/java/com/redhat/lightblue/migrator/facade/sharedstore/SharedStoreTest.java
+++ b/facade/src/test/java/com/redhat/lightblue/migrator/facade/sharedstore/SharedStoreTest.java
@@ -113,6 +113,26 @@ public class SharedStoreTest {
         Assert.assertFalse(store.isDualMigrationPhase());
     }
 
+    @Test
+    public void testClear() {
+        SharedStoreImpl store = new SharedStoreImpl(SharedStoreTest.class);
+        store.push(101l);
+        store.push(102l);
+        store.setDualMigrationPhase(true);
+
+        store.clear();
+
+        try {
+            store.pop();
+            Assert.fail();
+        } catch (SharedStoreException e) {}
+
+        try {
+            store.isDualMigrationPhase();
+            Assert.fail();
+        } catch (SharedStoreException e) {}
+    }
+
     class TestThread extends Thread {
 
         private SharedStore store;


### PR DESCRIPTION
Thread Ids are unique, but can be reused. That means shared data created by previous thread can be accessed by the current thread with the same id, assuming the data does not expire and it is not consumed by the originating thread (there is an error before shared data is consumed).