### PR TITLE
Consistency check performance test

### DIFF
--- a/facade/pom.xml
+++ b/facade/pom.xml
@@ -85,6 +85,12 @@
         <artifactId>togglz-junit</artifactId>
         <scope>test</scope>
     </dependency>
+    <dependency>
+        <groupId>com.redhat.lightblue.migrator</groupId>
+        <artifactId>jiff</artifactId>
+        <version>2.17.0-SNAPSHOT</version>
+    </dependency>
+
 
   </dependencies>
   <build>
@@ -96,6 +102,16 @@
         <configuration>
           <source>1.7</source>
           <target>1.7</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.19.1</version>
+        <configuration>
+          <excludes>
+            <exclude>**/ConsistencyCheckPerforformanceTest.java</exclude>
+          </excludes>
         </configuration>
       </plugin>
     </plugins>

--- a/facade/src/test/java/com/redhat/lightblue/migrator/facade/ConsistencyCheckPerforformanceTest.java
+++ b/facade/src/test/java/com/redhat/lightblue/migrator/facade/ConsistencyCheckPerforformanceTest.java
@@ -1,0 +1,92 @@
+package com.redhat.lightblue.migrator.facade;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.UUID;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jiff.JsonDiff;
+
+/**
+ * Test consistency check time for a list of objects, ignoring order.
+ *
+ * @author mpatercz
+ *
+ */
+public class ConsistencyCheckPerforformanceTest {
+
+    private static final Logger log = LoggerFactory.getLogger(ConsistencyCheckPerforformanceTest.class);
+
+    int FOO_COUNT = 10000;
+
+    List<Foo> fooList = new ArrayList<Foo>();
+
+    Random random = new Random();
+
+    class Foo {
+        public Foo(String strField1, String strField2, Long longField3) {
+            super();
+            this.strField1 = strField1;
+            this.strField2 = strField2;
+            this.longField3 = longField3;
+        }
+        public String strField1;
+        public String strField2;
+        public Long longField3;
+    }
+
+    private Foo generateRandomFoo() {
+        return new Foo(UUID.randomUUID()+" "+UUID.randomUUID(), UUID.randomUUID()+" "+UUID.randomUUID(), random.nextLong());
+    }
+
+    public ConsistencyCheckPerforformanceTest() {
+        log.info("Generating "+FOO_COUNT+" Foo objects");
+        for (int i=0;i<FOO_COUNT;i++) {
+            fooList.add(generateRandomFoo());
+        }
+        log.info("Generation complete");
+    }
+
+    /**
+     * On my machine: Consistency check took: 432 ms.
+     *
+     */
+    @Test
+    public void testConsistencyCheckerPerformance() {
+        ConsistencyChecker c = new ConsistencyChecker("Bar");
+        Timer t = new Timer("checkConsistency");
+        Assert.assertTrue(c.checkConsistency(fooList, fooList));
+        long tookMs = t.complete();
+        log.info("Total consistency check (including conversion to json) took "+tookMs+"ms");
+    }
+
+    /**
+     * On my machine: Jiff consistency check took 113ms.
+     *
+     * @throws IOException
+     */
+    @Test
+    public void testJiffPerformance() throws IOException {
+
+        String jsonStr = new ObjectMapper().writeValueAsString(fooList);
+
+        log.info("Json str size: "+jsonStr.length()/1024+"kB");
+
+        JsonDiff diff=new JsonDiff();
+        diff.setOption(JsonDiff.Option.ARRAY_ORDER_INSIGNIFICANT);
+
+        Timer t = new Timer("computeDiff");
+        Assert.assertTrue(diff.computeDiff(jsonStr, jsonStr).isEmpty());
+        long tookMs = t.complete();
+        log.info("Jiff consistency check took "+tookMs+"ms");
+    }
+
+}

--- a/facade/src/test/resources/simplelogger.properties
+++ b/facade/src/test/resources/simplelogger.properties
@@ -1,1 +1,2 @@
 org.slf4j.simpleLogger.defaultLogLevel=INFO
+org.slf4j.simpleLogger.log.com.redhat.lightblue.migrator.facade=DEBUG


### PR DESCRIPTION
@bserdar 

Jiff is ~4 times faster than ConsistencyChecker implementation using JSONCompare. As far as I remember, we're not using Jiff in the facade because it does not do pretty diffs. How much effort would it be to change that?

We could also use both methods:

- Jiff to check for consistency and then JSONCompare in a new thread only if there is inconsistency 
- No need to worry about ignoring fields, since this is handled during serialization to json. Both Jiff and JSONCompare would use the same settings to ignore fields, there is no risk of those being different.

Thoughts?