### PR TITLE
fixes #323 - compilation should use jdk7, but testing jdk8

### DIFF
--- a/bean-consistency-checker/pom.xml
+++ b/bean-consistency-checker/pom.xml
@@ -41,17 +41,4 @@
 
 
   </dependencies>
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.1</version>
-        <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/facade/pom.xml
+++ b/facade/pom.xml
@@ -96,15 +96,6 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.1</version>
-        <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.19.1</version>
         <configuration>

--- a/jiff/pom.xml
+++ b/jiff/pom.xml
@@ -36,6 +36,19 @@
           <source>1.7</source>
           <target>1.7</target>
         </configuration>
+        <executions>
+          <execution>
+            <id>test-compile</id>
+            <phase>process-test-sources</phase>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+            <configuration>
+              <source>1.8</source>
+              <target>1.8</target>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/jiff/pom.xml
+++ b/jiff/pom.xml
@@ -31,7 +31,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.3.2</version>
+        <version>3.0</version>
         <configuration>
           <source>1.7</source>
           <target>1.7</target>

--- a/jiff/pom.xml
+++ b/jiff/pom.xml
@@ -36,19 +36,6 @@
           <source>1.7</source>
           <target>1.7</target>
         </configuration>
-        <executions>
-          <execution>
-            <id>test-compile</id>
-            <phase>process-test-sources</phase>
-            <goals>
-              <goal>testCompile</goal>
-            </goals>
-            <configuration>
-              <source>1.8</source>
-              <target>1.8</target>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/jiff/pom.xml
+++ b/jiff/pom.xml
@@ -30,15 +30,6 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.0</version>
-        <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
         <version>2.3</version>
         <executions>

--- a/migrator/pom.xml
+++ b/migrator/pom.xml
@@ -100,15 +100,6 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.3.2</version>
-        <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
         <version>2.3</version>
         <executions>

--- a/migrator/pom.xml
+++ b/migrator/pom.xml
@@ -134,16 +134,6 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.4.2</version>
-        <configuration>
-          <skipTests>false</skipTests>
-          <forkCount>1</forkCount>
-          <reuseForks>false</reuseForks>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
   <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -177,10 +177,11 @@
        <plugin>
          <groupId>org.apache.maven.plugins</groupId>
          <artifactId>maven-surefire-plugin</artifactId>
-         <version>2.18.1</version>
+         <version>2.19.1</version>
          <configuration>
              <forkCount>1</forkCount>
              <reuseForks>false</reuseForks>
+             <skipTests>true</skipTests> <!-- jdk7 will fail if tests are executed because upstream deps are jdk8 only -->
          </configuration>
        </plugin>
        <plugin>
@@ -190,7 +191,6 @@
          <configuration>
            <source>1.7</source>
            <target>1.7</target>
-           <skipTests>true</skipTests>
          </configuration>
        </plugin>
        <plugin>
@@ -233,6 +233,15 @@
                   <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
+                  </configuration>
+                </plugin>
+                <plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-surefire-plugin</artifactId>
+                  <configuration>
+                      <forkCount>1</forkCount>
+                      <reuseForks>false</reuseForks>
+                      <skipTests>false</skipTests> <!-- jdk8 should run tests -->
                   </configuration>
                 </plugin>
             </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -185,11 +185,24 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.3.2</version>
+        <version>3.0</version>
         <configuration>
           <source>1.7</source>
           <target>1.7</target>
         </configuration>
+        <executions>
+          <execution>
+            <id>test-compile</id>
+            <phase>process-test-sources</phase>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+            <configuration>
+              <source>1.8</source>
+              <target>1.8</target>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.eluder.coveralls</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -189,20 +189,8 @@
         <configuration>
           <source>1.7</source>
           <target>1.7</target>
+          <skipTests>true</skipTests>
         </configuration>
-        <executions>
-          <execution>
-            <id>test-compile</id>
-            <phase>process-test-sources</phase>
-            <goals>
-              <goal>testCompile</goal>
-            </goals>
-            <configuration>
-              <source>1.8</source>
-              <target>1.8</target>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
       <plugin>
         <groupId>org.eluder.coveralls</groupId>
@@ -236,6 +224,15 @@
                     <configuration>
                         <additionalparam>-Xdoclint:none</additionalparam>
                     </configuration>
+                </plugin>
+                <plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-compiler-plugin</artifactId>
+                  <version>3.0</version>
+                  <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                  </configuration>
                 </plugin>
             </plugins>
         </build>

--- a/pom.xml
+++ b/pom.xml
@@ -185,7 +185,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.0</version>
+        <version>3.5.1</version>
         <configuration>
           <source>1.7</source>
           <target>1.7</target>
@@ -228,7 +228,7 @@
                 <plugin>
                   <groupId>org.apache.maven.plugins</groupId>
                   <artifactId>maven-compiler-plugin</artifactId>
-                  <version>3.0</version>
+                  <version>3.5.1</version>
                   <configuration>
                     <source>1.8</source>
                     <target>1.8</target>

--- a/pom.xml
+++ b/pom.xml
@@ -172,43 +172,45 @@
     </dependencies>
   </dependencyManagement>
   <build>
+  <pluginManagement>
     <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.18.1</version>
-        <configuration>
-            <forkCount>1</forkCount>
-            <reuseForks>false</reuseForks>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.5.1</version>
-        <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
-          <skipTests>true</skipTests>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.eluder.coveralls</groupId>
-        <artifactId>coveralls-maven-plugin</artifactId>
-        <version>3.0.1</version>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>cobertura-maven-plugin</artifactId>
-        <version>2.6</version>
-        <configuration>
-          <format>xml</format>
-          <maxmem>256m</maxmem>
-          <!-- aggregated reports for multi-module projects -->
-          <aggregate>true</aggregate>
-        </configuration>
-      </plugin>
-    </plugins>
+       <plugin>
+         <groupId>org.apache.maven.plugins</groupId>
+         <artifactId>maven-surefire-plugin</artifactId>
+         <version>2.18.1</version>
+         <configuration>
+             <forkCount>1</forkCount>
+             <reuseForks>false</reuseForks>
+         </configuration>
+       </plugin>
+       <plugin>
+         <groupId>org.apache.maven.plugins</groupId>
+         <artifactId>maven-compiler-plugin</artifactId>
+         <version>3.5.1</version>
+         <configuration>
+           <source>1.7</source>
+           <target>1.7</target>
+           <skipTests>true</skipTests>
+         </configuration>
+       </plugin>
+       <plugin>
+         <groupId>org.eluder.coveralls</groupId>
+         <artifactId>coveralls-maven-plugin</artifactId>
+         <version>3.0.1</version>
+       </plugin>
+       <plugin>
+         <groupId>org.codehaus.mojo</groupId>
+         <artifactId>cobertura-maven-plugin</artifactId>
+         <version>2.6</version>
+         <configuration>
+           <format>xml</format>
+           <maxmem>256m</maxmem>
+           <!-- aggregated reports for multi-module projects -->
+           <aggregate>true</aggregate>
+         </configuration>
+       </plugin>
+     </plugins>
+    </pluginManagement>
   </build>
   <profiles>
     <profile>
@@ -228,7 +230,6 @@
                 <plugin>
                   <groupId>org.apache.maven.plugins</groupId>
                   <artifactId>maven-compiler-plugin</artifactId>
-                  <version>3.5.1</version>
                   <configuration>
                     <source>1.8</source>
                     <target>1.8</target>


### PR DESCRIPTION
Fixes https://github.com/lightblue-platform/lightblue-migrator/issues/323

This change will compile using jdk7, but run tests with jdk8.