### PR TITLE
Fixing boolean consistency check

### DIFF
--- a/facade/src/main/java/com/redhat/lightblue/migrator/facade/ConsistencyChecker.java
+++ b/facade/src/main/java/com/redhat/lightblue/migrator/facade/ConsistencyChecker.java
@@ -194,6 +194,12 @@ public class ConsistencyChecker {
             String legacyJsonStr =  objectMapper.writeValueAsString(legacyEntity);
             String lightblueJsonStr =  objectMapper.writeValueAsString(lightblueEntity);
 
+            // JSONCompare fails when comparing booleans, convert them to strings
+            if ("true".equals(legacyJsonStr) || "false".equals(legacyJsonStr))
+                legacyJsonStr = "\""+legacyJsonStr+"\"";
+            if ("true".equals(lightblueJsonStr) || "false".equals(lightblueJsonStr))
+                lightblueJsonStr = "\""+lightblueJsonStr+"\"";
+
             if ("null".equals(legacyJsonStr) || "null".equals(lightblueJsonStr)) {
                 logInconsistency(Thread.currentThread().getName(), callToLogInCaseOfInconsistency.toString(), legacyJsonStr, lightblueJsonStr, "One object is null and the other isn't");
             } else {

--- a/facade/src/test/java/com/redhat/lightblue/migrator/facade/ConsistencyCheckTest.java
+++ b/facade/src/test/java/com/redhat/lightblue/migrator/facade/ConsistencyCheckTest.java
@@ -15,6 +15,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.togglz.junit.TogglzRule;
 
 import com.redhat.lightblue.migrator.facade.model.Country;
@@ -29,8 +30,7 @@ import com.redhat.lightblue.migrator.features.LightblueMigrationFeatures;
 @RunWith(MockitoJUnitRunner.class)
 public class ConsistencyCheckTest {
 
-    @Mock
-    private Logger inconsistencyLog;
+    private Logger inconsistencyLog = Mockito.spy(LoggerFactory.getLogger(ConsistencyChecker.class));
 
     @Rule
     public TogglzRule togglzRule = TogglzRule.allDisabled(LightblueMigrationFeatures.class);

--- a/facade/src/test/java/com/redhat/lightblue/migrator/facade/ConsistencyCheckTest.java
+++ b/facade/src/test/java/com/redhat/lightblue/migrator/facade/ConsistencyCheckTest.java
@@ -67,7 +67,6 @@ public class ConsistencyCheckTest {
         Assert.assertTrue(consistencyChecker.checkConsistency(null, null)); // no log
         Assert.assertFalse(consistencyChecker.checkConsistency(null, new Country()));
         Assert.assertFalse(consistencyChecker.checkConsistency(new Country(), null));
-        Mockito.verify(inconsistencyLog, Mockito.times(2)).warn(Mockito.anyString());
 
         Country c1 = new Country(1l, null);
         Country c2 = new Country(1l, null);
@@ -80,6 +79,32 @@ public class ConsistencyCheckTest {
 
         // 4 inconsistencies means 4 warnings
         Mockito.verify(inconsistencyLog, Mockito.times(4)).warn(Mockito.anyString());
+    }
+
+    @Test
+    public void testConsistencyWithPrimitives() {
+        Assert.assertTrue(consistencyChecker.checkConsistency("string", "string")); // no log
+        Assert.assertTrue(consistencyChecker.checkConsistency(12, 12)); // no log
+        Assert.assertTrue(consistencyChecker.checkConsistency(12.0d, 12.0d)); // no log
+        Assert.assertTrue(consistencyChecker.checkConsistency(12l, 12l)); // no log
+        Assert.assertTrue(consistencyChecker.checkConsistency(true, true));
+        Assert.assertTrue(consistencyChecker.checkConsistency(false, false));
+        // In some cases, this is not a type safe check. That's fine.
+        Assert.assertTrue(consistencyChecker.checkConsistency(12, 12l));
+        Assert.assertTrue(consistencyChecker.checkConsistency(new Integer(12), 12));
+        Assert.assertTrue(consistencyChecker.checkConsistency(new Boolean(false), false));
+
+        // inconsistencies
+        Assert.assertFalse(consistencyChecker.checkConsistency("foo", "bar"));
+        Assert.assertFalse(consistencyChecker.checkConsistency(true, false));
+        Assert.assertFalse(consistencyChecker.checkConsistency(false, true));
+        Assert.assertFalse(consistencyChecker.checkConsistency(true, null));
+        Assert.assertFalse(consistencyChecker.checkConsistency(null, false));
+        Assert.assertFalse(consistencyChecker.checkConsistency(12, 13));
+        Assert.assertFalse(consistencyChecker.checkConsistency(new Boolean(true), null));
+
+        // 7 inconsistencies means 7 warnings
+        Mockito.verify(inconsistencyLog, Mockito.times(7)).warn(Mockito.anyString());
     }
 
     @Test


### PR DESCRIPTION
JSONCompare errors when comparing booleans:

```
2016-04-04 17:04:06,546 [Thread-245880] ERROR [com.redhat.lightblue.migrator.facade.ConsistencyChecker] JSONCompare consistency check failed for isDisabled(amartin_pseg-li): org.json.JSONException: Unparsable JSON string: true
	at org.skyscreamer.jsonassert.JSONParser.parseJSON(JSONParser.java:42)
	at org.skyscreamer.jsonassert.JSONCompare.compareJSON(JSONCompare.java:35)
	at org.skyscreamer.jsonassert.JSONCompare.compareJSON(JSONCompare.java:109)
	at com.redhat.lightblue.migrator.facade.ConsistencyChecker.logInconsistencyUsingJSONCompare(ConsistencyChecker.java:110)
	at com.redhat.lightblue.migrator.facade.ConsistencyChecker.access$000(ConsistencyChecker.java:28)
	at com.redhat.lightblue.migrator.facade.ConsistencyChecker$1.run(ConsistencyChecker.java:141)
	at java.lang.Thread.run(Thread.java:745)
```