### PR TITLE
update the rpm install path to match what puppet uses

### DIFF
--- a/lightblue-migration-monitor/pom.xml
+++ b/lightblue-migration-monitor/pom.xml
@@ -9,7 +9,7 @@
   <artifactId>lightblue-migration-monitor</artifactId>
   
   <properties>
-    <rpm.install.basedir>/usr/share/migrator/monitor</rpm.install.basedir>
+    <rpm.install.basedir>/usr/share/lightblue-migrator/monitor</rpm.install.basedir>
   </properties>
   
   <dependencies>

--- a/migrator/pom.xml
+++ b/migrator/pom.xml
@@ -13,7 +13,7 @@
     <apache.commons-io.version>2.4</apache.commons-io.version>
     <log4j.version>1.2.17</log4j.version>
     <junit.version>4.12</junit.version>
-    <rpm.install.basedir>/usr/share/migrator</rpm.install.basedir>
+    <rpm.install.basedir>/usr/share/lightblue-migrator</rpm.install.basedir>
   </properties>
   <dependencies>
     <dependency>


### PR DESCRIPTION
Make match with default used in https://github.com/lightblue-platform/lightblue-puppet/blob/master/manifests/application/migrator.pp#L71