### PR TITLE
add symlink to rpm as shortcut for external applications

### DIFF
--- a/migrator/pom.xml
+++ b/migrator/pom.xml
@@ -161,6 +161,11 @@
                     <source>
                       <location>target/${project.artifactId}-${project.version}-alldeps.${project.packaging}</location>
                     </source>
+                    <softlinkSource>
+                      <!-- Makes it easier for external applications to execute that application without needing to know the version -->
+                      <location>${project.artifactId}-${project.version}-alldeps.${project.packaging}</location>
+                      <destination>${project.artifactId}-alldeps.${project.packaging}</destination>
+                    </softlinkSource>
                   </sources>
                 </mapping>
               </mappings>


### PR DESCRIPTION
A minor change, but should allow our puppet script to not have to use a wildcard character to work around jar version while still allowing us to know what version is deployed.