### PR TITLE
Try to interrupt timed out calls

### DIFF
--- a/facade/src/main/java/com/redhat/lightblue/migrator/facade/ServiceFacade.java
+++ b/facade/src/main/java/com/redhat/lightblue/migrator/facade/ServiceFacade.java
@@ -295,7 +295,7 @@ public class ServiceFacade<D extends SharedStoreSetter> implements SharedStoreSe
                 }
             } catch (TimeoutException te) {
 
-                if (timeoutConfiguration.isInterruptOnTimeout()) {
+                if (timeoutConfiguration.isInterruptOnTimeout() && facadeOperation == FacadeOperation.READ) {
                     // try to interrupt the thread
                     try {
                         listenableFuture.cancel(true);

--- a/facade/src/main/java/com/redhat/lightblue/migrator/facade/ServiceFacade.java
+++ b/facade/src/main/java/com/redhat/lightblue/migrator/facade/ServiceFacade.java
@@ -294,6 +294,16 @@ public class ServiceFacade<D extends SharedStoreSetter> implements SharedStoreSe
                     lightblueEntity = getWithTimeout(listenableFuture, methodName, facadeOperation, shouldSource(facadeOperation));
                 }
             } catch (TimeoutException te) {
+
+                if (timeoutConfiguration.isInterruptOnTimeout()) {
+                    // try to interrupt the thread
+                    try {
+                        listenableFuture.cancel(true);
+                    } catch (Exception e) {
+                        log.error("Failed to cancel lightblue call", e);
+                    }
+                }
+
                 if (shouldSource(facadeOperation)) {
                     log.warn("Lightblue call " + implementationName + "." + callStringifier + " is taking too long (longer than " + timeoutConfiguration.getTimeoutMS(methodName, facadeOperation) + "s). Returning data from legacy.");
                     return legacyEntity;

--- a/facade/src/main/java/com/redhat/lightblue/migrator/facade/TimeoutConfiguration.java
+++ b/facade/src/main/java/com/redhat/lightblue/migrator/facade/TimeoutConfiguration.java
@@ -45,6 +45,7 @@ public class TimeoutConfiguration {
     private long defaultTimeoutMS;
     private String beanName;
     private Properties properties;
+    private boolean interruptOnTimeout = true;
 
     private HashMap<String, Long> methodTimeouts = new HashMap<>();
 
@@ -65,7 +66,12 @@ public class TimeoutConfiguration {
             this.properties = new Properties();
         }
 
-        log.info("Initialized TimeoutConfiguration for {}", beanName);
+        if (properties != null) {
+            // interruptOnTimeout key does not include bean name - it is global
+            interruptOnTimeout = Boolean.parseBoolean(properties.getProperty(TimeoutConfiguration.CONFIG_PREFIX+".timeout.interruptOnTimeout", "true"));
+        }
+
+        log.info("Initialized TimeoutConfiguration for {}, interruptOnTimeout={}", beanName, interruptOnTimeout);
     }
 
     /**
@@ -148,6 +154,14 @@ public class TimeoutConfiguration {
      */
     public long getSlowWarningMS(String methodName, FacadeOperation op) {
         return getMS(methodName, op, Type.slowwarning);
+    }
+
+    public boolean isInterruptOnTimeout() {
+        return interruptOnTimeout;
+    }
+
+    public void setInterruptOnTimeout(boolean interruptOnTimeout) {
+        this.interruptOnTimeout = interruptOnTimeout;
     }
 
 }


### PR DESCRIPTION
Restoring interrupting timed out lightblue calls.

This should help with "java.lang.OutOfMemoryError: Unable to create new native thread" errors, although it's not full protection, like thread pools. 