### PR TITLE
Log api which threw an exception

### DIFF
--- a/facade/src/main/java/com/redhat/lightblue/migrator/facade/ServiceFacade.java
+++ b/facade/src/main/java/com/redhat/lightblue/migrator/facade/ServiceFacade.java
@@ -313,7 +313,7 @@ public class ServiceFacade<D extends SharedStoreSetter> implements SharedStoreSe
                 }
             } catch (Throwable e) {
                 if (shouldSource(facadeOperation)) {
-                    log.warn("Error when calling lightblue DAO. Returning data from legacy.", e);
+                    log.warn("Lightblue call " + implementationName + "." + callStringifier + " threw an exception. Returning data from legacy.", e);
                     return legacyEntity;
                 } else {
                     throw extractUnderlyingException(e);


### PR DESCRIPTION
Facade already logs full stack traces of exceptions thrown by Lightblue implementations. This change makes it possible to query logs for exceptions thrown by particular service (even particular api).