### PR TITLE
Select job type (generated or not) according to weights specified in configuration

### DIFF
--- a/migrator/pom.xml
+++ b/migrator/pom.xml
@@ -74,12 +74,12 @@
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
+    <!-- https://mvnrepository.com/artifact/org.mockito/mockito-all -->
     <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <version>2.0.36-beta</version>
-      <scope>test</scope>
-   </dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-all</artifactId>
+        <version>2.0.2-beta</version>
+    </dependency>
    <dependency>
      <groupId>com.redhat.lightblue.client</groupId>
      <artifactId>lightblue-client-integration-test</artifactId>

--- a/migrator/src/main/java/com/redhat/lightblue/migrator/AbstractController.java
+++ b/migrator/src/main/java/com/redhat/lightblue/migrator/AbstractController.java
@@ -1,23 +1,22 @@
 package com.redhat.lightblue.migrator;
 
-import java.io.IOException;
-
-import java.util.UUID;
 import java.util.Date;
 import java.util.HashSet;
+import java.util.Random;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.redhat.lightblue.client.LightblueClient;
 import com.redhat.lightblue.client.Locking;
-import com.redhat.lightblue.client.Query;
-import com.redhat.lightblue.client.Projection;
-import com.redhat.lightblue.client.request.data.DataInsertRequest;
-import com.redhat.lightblue.client.request.data.DataDeleteRequest;
-import com.redhat.lightblue.client.response.LightblueResponse;
 
 public abstract class AbstractController extends Thread {
+
+    public enum JobType {
+        GENERATED, NONGENERATED, ANY;
+    }
+
+    public static final Random random = new Random(new Date().getTime());
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractController.class);
 

--- a/migrator/src/main/java/com/redhat/lightblue/migrator/ConsistencyCheckerController.java
+++ b/migrator/src/main/java/com/redhat/lightblue/migrator/ConsistencyCheckerController.java
@@ -227,73 +227,68 @@ public class ConsistencyCheckerController extends AbstractController {
                 migrationConfiguration=newCfg;
                 // Lets recalculate period, just in case it changed
                 period=parsePeriod(migrationConfiguration.getPeriod());
-                
-                if(migrationJobsExist()) {
-                    LOGGER.info("There are migration jobs for {}, not running consistency checker this time",
-                                migrationConfiguration.getConfigurationName());
-                } else {
                     
-                    // We abuse the migration job locking mechanism
-                    // here to make sure only one consistency checker
-                    // controller is up at any given time This process
-                    // only creates migration jobs for the new
-                    // periods, so this is not a high-load process,
-                    // and we don't need many instances of it
-                    // running. But since the migrator can run on
-                    // multiple hosts, there is no way to prevent
-                    // it. At least, we make sure only one of the
-                    // consistencyy checker controllers wakes up at
-                    // any given time.
-                    
-                    // We create a lock using a custom id:
-                    String lockId=migrationConfiguration.getConfigurationName()+":ConsistencyCheckerController";
-                    ActiveExecution ae;
+                // We abuse the migration job locking mechanism
+                // here to make sure only one consistency checker
+                // controller is up at any given time This process
+                // only creates migration jobs for the new
+                // periods, so this is not a high-load process,
+                // and we don't need many instances of it
+                // running. But since the migrator can run on
+                // multiple hosts, there is no way to prevent
+                // it. At least, we make sure only one of the
+                // consistencyy checker controllers wakes up at
+                // any given time.
+
+                // We create a lock using a custom id:
+                String lockId=migrationConfiguration.getConfigurationName()+":ConsistencyCheckerController";
+                ActiveExecution ae;
+                try {
+                    ae=lock(lockId);
+                } catch (Exception e) {
+                    LOGGER.error("Exception during lock attempt {}:{}",lockId,e);
+                    ae=null;
+                }
+                if(ae!=null) {
+                    Breakpoint.checkpoint("CCC:locked");
+                    LOGGER.debug("This is the only running consistency checker instance for {}",migrationConfiguration.getConfigurationName());
                     try {
-                        ae=lock(lockId);
-                    } catch (Exception e) {
-                        LOGGER.error("Exception during lock attempt {}:{}",lockId,e);
-                        ae=null;
-                    }
-                    if(ae!=null) {
-                        Breakpoint.checkpoint("CCC:locked");
-                        LOGGER.debug("This is the only running consistency checker instance for {}",migrationConfiguration.getConfigurationName());
-                        try {
-                            Date endDate=null;
-                            Date startDate= migrationConfiguration.getTimestampInitialValue();
-                            if(startDate!=null) {
-                                endDate=getEndDate(startDate,period);
-                                if(endDate==null) {
-                                    LOGGER.debug("{} will wait for next period",migrationConfiguration.getConfigurationName());
-                                } else {
-                                    Breakpoint.checkpoint("CCC:beforeCreateJobs");
-                                    List<MigrationJob> mjList=new ArrayList<>();
-                                    do {
-                                        LOGGER.debug("{} will create a job for period {}-{}",migrationConfiguration.getConfigurationName(),startDate,endDate);
-                                        mjList.addAll(createJobs(startDate,endDate,ae));
-                                        migrationConfiguration.setTimestampInitialValue(endDate);
-                                        startDate=endDate;
-                                        endDate=getEndDate(startDate,period);
-                                    } while(endDate!=null&&!stopped);
-                                    if(!mjList.isEmpty()&&!stopped) {
-                                        try {
-                                            update(mjList);
-                                        } catch (Exception e) {
-                                            LOGGER.error("Cannot create jobs:{}",e,e);
-                                        }
+                        Date endDate=null;
+                        Date startDate= migrationConfiguration.getTimestampInitialValue();
+                        if(startDate!=null) {
+                            endDate=getEndDate(startDate,period);
+                            if(endDate==null) {
+                                LOGGER.debug("{} will wait for next period",migrationConfiguration.getConfigurationName());
+                            } else {
+                                Breakpoint.checkpoint("CCC:beforeCreateJobs");
+                                List<MigrationJob> mjList=new ArrayList<>();
+                                do {
+                                    LOGGER.debug("{} will create a job for period {}-{}",migrationConfiguration.getConfigurationName(),startDate,endDate);
+                                    mjList.addAll(createJobs(startDate,endDate,ae));
+                                    migrationConfiguration.setTimestampInitialValue(endDate);
+                                    startDate=endDate;
+                                    endDate=getEndDate(startDate,period);
+                                } while(endDate!=null&&!stopped);
+                                if(!mjList.isEmpty()&&!stopped) {
+                                    try {
+                                        update(mjList);
+                                    } catch (Exception e) {
+                                        LOGGER.error("Cannot create jobs:{}",e,e);
                                     }
-                                    LOGGER.debug("Created all the jobs");
-                                    Breakpoint.checkpoint("CCC:afterCreateJobs");
                                 }
-                            } else
-                                LOGGER.error("Invalid timestamp initial value for {}, skipping this run",migrationConfiguration.getConfigurationName());
-                        } catch(Exception e) {
-                            LOGGER.error("Error during job creation:{}",e,e);
-                        } finally {
-                            LOGGER.debug("Unlocking consistency checker {}",migrationConfiguration.getConfigurationName());
-                            unlock(lockId);
-                        }
+                                LOGGER.debug("Created all the jobs");
+                                Breakpoint.checkpoint("CCC:afterCreateJobs");
+                            }
+                        } else
+                            LOGGER.error("Invalid timestamp initial value for {}, skipping this run",migrationConfiguration.getConfigurationName());
+                    } catch(Exception e) {
+                        LOGGER.error("Error during job creation:{}",e,e);
+                    } finally {
+                        LOGGER.debug("Unlocking consistency checker {}",migrationConfiguration.getConfigurationName());
+                        unlock(lockId);
                     }
                 }
+
             }
             if(!stopped) {
                 try {

--- a/migrator/src/main/java/com/redhat/lightblue/migrator/Controller.java
+++ b/migrator/src/main/java/com/redhat/lightblue/migrator/Controller.java
@@ -11,7 +11,6 @@ import com.redhat.lightblue.client.LightblueClient;
 import com.redhat.lightblue.client.LightblueException;
 import com.redhat.lightblue.client.Projection;
 import com.redhat.lightblue.client.Query;
-import com.redhat.lightblue.client.http.LightblueHttpClient;
 import com.redhat.lightblue.client.request.data.DataFindRequest;
 
 /**
@@ -115,13 +114,8 @@ public class Controller extends Thread {
     }
 
     public LightblueClient getLightblueClient() {
-        LightblueHttpClient httpClient;
         LOGGER.debug("Getting client, config={}", cfg.getClientConfig());
-        if (cfg.getClientConfig() != null) {
-            return new LightblueHttpClient(cfg.getClientConfig());
-        } else {
-            return new LightblueHttpClient();
-        }
+        return cfg.getLightblueClient();
     }
 
     private boolean shouldHaveConsistencyChecker(MigrationConfiguration cfg) {

--- a/migrator/src/main/java/com/redhat/lightblue/migrator/MainConfiguration.java
+++ b/migrator/src/main/java/com/redhat/lightblue/migrator/MainConfiguration.java
@@ -8,6 +8,9 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 
+import com.redhat.lightblue.client.LightblueClient;
+import com.redhat.lightblue.client.http.LightblueHttpClient;
+
 public class MainConfiguration {
 
     public static final Options options;
@@ -68,6 +71,14 @@ public class MainConfiguration {
 
     public String getClientConfig() {
         return clientConfig;
+    }
+
+    public LightblueClient getLightblueClient() {
+        if (getClientConfig() != null) {
+            return new LightblueHttpClient(getClientConfig());
+        } else {
+            return new LightblueHttpClient();
+        }
     }
 
     public void setClientConfig(String s) {

--- a/migrator/src/main/java/com/redhat/lightblue/migrator/MigrationConfiguration.java
+++ b/migrator/src/main/java/com/redhat/lightblue/migrator/MigrationConfiguration.java
@@ -3,6 +3,8 @@ package com.redhat.lightblue.migrator;
 import java.util.Date;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 public class MigrationConfiguration {
 
     public static final String ENTITY_NAME = "migrationConfiguration";
@@ -41,6 +43,8 @@ public class MigrationConfiguration {
      * </pre>
      */
     private String period;
+
+    private boolean sleepIfNoJobs = true;
 
     /**
      * Gets the value of _id
@@ -439,5 +443,15 @@ public class MigrationConfiguration {
 
     public void setMigratorWeight(double migratorWeight) {
         this.migratorWeight = migratorWeight;
+    }
+
+    @JsonIgnore
+    public boolean isSleepIfNoJobs() {
+        return sleepIfNoJobs;
+    }
+
+    @JsonIgnore
+    public void setSleepIfNoJobs(boolean sleepIfNoJobs) {
+        this.sleepIfNoJobs = sleepIfNoJobs;
     }
 }

--- a/migrator/src/main/java/com/redhat/lightblue/migrator/MigrationConfiguration.java
+++ b/migrator/src/main/java/com/redhat/lightblue/migrator/MigrationConfiguration.java
@@ -1,7 +1,7 @@
 package com.redhat.lightblue.migrator;
 
-import java.util.List;
 import java.util.Date;
+import java.util.List;
 
 public class MigrationConfiguration {
 
@@ -11,6 +11,8 @@ public class MigrationConfiguration {
     private String configurationName;
     private String consistencyCheckerName;
     private int threadCount;
+    private double consistencyCheckerWeight = 1f;
+    private double migratorWeight = 1f;
     private String migratorClass;
     private String consistencyCheckerControllerClass;
     private boolean overwriteDestinationDocuments = false;
@@ -421,5 +423,21 @@ public class MigrationConfiguration {
         sb.append("sourceEntityVersion=").append(sourceEntityVersion);
 
         return sb.toString();
+    }
+
+    public double getConsistencyCheckerWeight() {
+        return consistencyCheckerWeight;
+    }
+
+    public void setConsistencyCheckerWeight(double consistencyCheckerWeight) {
+        this.consistencyCheckerWeight = consistencyCheckerWeight;
+    }
+
+    public double getMigratorWeight() {
+        return migratorWeight;
+    }
+
+    public void setMigratorWeight(double migratorWeight) {
+        this.migratorWeight = migratorWeight;
     }
 }

--- a/migrator/src/main/java/com/redhat/lightblue/migrator/MigratorController.java
+++ b/migrator/src/main/java/com/redhat/lightblue/migrator/MigratorController.java
@@ -207,9 +207,11 @@ public class MigratorController extends AbstractController {
                         m.registerThreadMonitor(monitor);
                         m.start();
                     } else {
-                        // No jobs are available, wait a bit (10sec-30sec), and retry
-                        LOGGER.debug("Waiting for {}", migrationConfiguration.getConfigurationName());
-                        Thread.sleep(rnd.nextInt(20000) + 10000);
+                        if (migrationConfiguration.isSleepIfNoJobs()) {
+                            // No jobs are available, wait a bit (10sec-30sec), and retry
+                            LOGGER.debug("Waiting for {}", migrationConfiguration.getConfigurationName());
+                            Thread.sleep(rnd.nextInt(20000) + 10000);
+                        }
                     }
                 } catch (InterruptedException ie) {
                     Thread.currentThread().interrupt();

--- a/migrator/src/main/java/com/redhat/lightblue/migrator/MigratorController.java
+++ b/migrator/src/main/java/com/redhat/lightblue/migrator/MigratorController.java
@@ -1,6 +1,8 @@
 package com.redhat.lightblue.migrator;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
@@ -51,22 +53,31 @@ public class MigratorController extends AbstractController {
      * Retrieves jobs that are available, and their scheduled time has passed.
      * Returns at most batchSize jobs starting at startIndex
      */
-    public MigrationJob[] retrieveJobs(int batchSize, int startIndex)
+    public MigrationJob[] retrieveJobs(int batchSize, int startIndex, JobType jobType)
             throws IOException, LightblueException {
         LOGGER.debug("Retrieving jobs: batchSize={}, startIndex={}", batchSize, startIndex);
 
         DataFindRequest findRequest = new DataFindRequest("migrationJob", null);
 
-        findRequest.where(
-                Query.and(
-                        // get jobs for this configuration
-                        Query.withValue("configurationName", Query.eq, migrationConfiguration.getConfigurationName()),
-                        // get jobs whose state ara available
-                        Query.withValue("status", Query.eq, "available"),
-                        // only get jobs that are
-                        Query.withValue("scheduledDate", Query.lte, new Date())
-                )
-        );
+        List<Query> conditions = new ArrayList<>(Arrays.asList(new Query[] {
+                // get jobs for this configuration
+                Query.withValue("configurationName", Query.eq, migrationConfiguration.getConfigurationName()),
+                // get jobs whose state ara available
+                Query.withValue("status", Query.eq, "available"),
+                // only get jobs that are
+                Query.withValue("scheduledDate", Query.lte, new Date())
+        }));
+
+        if (jobType == JobType.GENERATED) {
+            LOGGER.debug("Looking for generated job");
+            conditions.add(Query.withValue("generated", Query.eq, true));
+        } else if (jobType == JobType.NONGENERATED) {
+            LOGGER.debug("Looking for non generated job");
+            conditions.add(Query.withValue("generated", Query.eq, false));
+        }
+
+        findRequest.where(Query.and(conditions));
+
         findRequest.select(Projection.includeField("*"));
 
         findRequest.range(startIndex, startIndex + batchSize - 1);
@@ -93,7 +104,13 @@ public class MigratorController extends AbstractController {
         try {
             do {
                 more = true;
-                MigrationJob[] jobs = retrieveJobs(JOB_FETCH_BATCH_SIZE, startIndex);
+                MigrationJob[] jobs = retrieveJobs(JOB_FETCH_BATCH_SIZE, startIndex, getJobTypeToProcess());
+
+                if (jobs == null || jobs.length == 0) {
+                    // didn't find the job kind we were looking for, so fetch any
+                    jobs = retrieveJobs(JOB_FETCH_BATCH_SIZE, startIndex, JobType.ANY);
+                }
+
                 if (jobs != null && jobs.length > 0) {
                     if (jobs.length < JOB_FETCH_BATCH_SIZE) {
                         more = false;
@@ -204,5 +221,22 @@ public class MigratorController extends AbstractController {
         migratorThreads.interrupt();
         Breakpoint.checkpoint("MigratorController:end");
         LOGGER.debug("Ending controller thread for {}", migrationConfiguration.getConfigurationName());
+    }
+
+    /**
+     * Draws JobType basing on weights defined in configuration. This is to ensure that generated (consistency checker) and
+     * non generated (migrator) jobs run in requested proportions.
+     *
+     * @param cfg
+     * @return
+     */
+    private JobType getJobTypeToProcess() {
+        double denominator = migrationConfiguration.getConsistencyCheckerWeight() + migrationConfiguration.getMigratorWeight();
+
+        if (random.nextDouble() <= migrationConfiguration.getConsistencyCheckerWeight() / denominator) {
+            return JobType.GENERATED;
+        } else {
+            return JobType.NONGENERATED;
+        }
     }
 }

--- a/migrator/src/main/resources/migrationConfiguration.json
+++ b/migrator/src/main/resources/migrationConfiguration.json
@@ -5,7 +5,7 @@
             "collection": "migrationConfig",
             "datasource": "mongodata"
         },
-        "defaultVersion" : "2.0.1",
+        "defaultVersion" : "2.0.2",
         "indexes": [
             {
                 "fields": [
@@ -74,6 +74,14 @@
                     "required": true
                 },
                 "description": "Name of the configuration.  Referenced by jobs."
+            },
+            "consistencyCheckerWeight": {
+                "type": "double",
+                "description": "How often select generated jobs for processing."
+            },
+            "migratorWeight": {
+                "type": "double",
+                "description": "How often select non generated jobs for processing."
             },
             "consistencyCheckerName": {
                 "type": "string",
@@ -185,8 +193,8 @@
             "value": "active"
         },
         "version": {
-            "changelog": "Consistency checker changes",
-            "value": "2.0.1"
+            "changelog": "Weights for migrator and consistency checker",
+            "value": "2.0.2"
         }
     }
 }

--- a/migrator/src/main/resources/migrationJob.json
+++ b/migrator/src/main/resources/migrationJob.json
@@ -30,6 +30,10 @@
                     {
                         "dir": "$asc",
                         "field": "scheduledDate"
+                    },
+                    {
+                        "dir": "$asc",
+                        "field": "generated"
                     }
                 ],
                 "name": "MigrationJobsToExecute",

--- a/migrator/src/test/java/com/redhat/lightblue/migrator/WeightsTest.java
+++ b/migrator/src/test/java/com/redhat/lightblue/migrator/WeightsTest.java
@@ -1,0 +1,95 @@
+package com.redhat.lightblue.migrator;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
+
+import com.redhat.lightblue.client.http.LightblueHttpClient;
+import com.redhat.lightblue.client.request.data.DataFindRequest;
+
+/**
+ * Verify that generated and non generated jobs are retrieved for processing in desired proportions, i.e. that
+ * migration and consistency checking can happen in parallel.
+ *
+ * @author mpatercz
+ *
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class WeightsTest {
+
+    double acceptableThreshold = 0.02;
+
+    @Mock LightblueHttpClient lightblueClient;
+
+    Controller controller;
+
+    @Test
+    public void testGeneratedAndNongeneratedJobsAreQueriedInEqualProportions() throws Exception {
+        MainConfiguration mainCfg = Mockito.spy(new MainConfiguration());
+        mainCfg.setName("TestWeightMainConfiguration");
+
+        MigrationConfiguration cfg = new MigrationConfiguration();
+        cfg.setConfigurationName("TestWeightConfiguration");
+        cfg.setThreadCount(1);
+        cfg.setPeriod(null); // no consistency check
+        cfg.setSleepIfNoJobs(false); // speed up things
+
+        // tie mocked client to main conf
+        Mockito.doReturn(lightblueClient).when(mainCfg).getLightblueClient();
+
+        controller = Mockito.spy(new Controller(mainCfg));
+
+        // handle conf reload
+        Mockito.doReturn(new MigrationConfiguration[]{cfg}).when(controller).getMigrationConfigurations();
+        Mockito.doReturn(cfg).when(lightblueClient).data(Mockito.isA(DataFindRequest.class), Mockito.eq(MigrationConfiguration.class));
+
+        final int[] generated = new int[1];
+        final int[] nongenerated = new int[1];
+        final int[] any = new int[1];
+
+        // observe migrationjob queries and count them by type
+        Mockito.when(lightblueClient.data(Mockito.isA(DataFindRequest.class), Mockito.eq(MigrationJob[].class))).thenAnswer(new Answer<MigrationJob[]>() {
+
+            @Override
+            public MigrationJob[] answer(InvocationOnMock invocation) throws Throwable {
+                DataFindRequest r = (DataFindRequest) invocation.getArguments()[0];
+
+                String body = r.getBody();
+
+                if (body.contains("{\"field\":\"generated\",\"op\":\"=\",\"rvalue\":true}")) {
+                    generated[0]++;
+                } else if (body.contains("{\"field\":\"generated\",\"op\":\"=\",\"rvalue\":false}")) {
+                    nongenerated[0]++;
+                } else {
+                    any[0]++;
+                }
+
+                return null;
+            }
+
+        });
+
+        controller.start();
+
+        Thread.sleep(2500);
+
+        controller.setStopped();
+
+        while(controller.isAlive()) {
+            Thread.sleep(10);
+        }
+
+        System.out.println("generated="+generated[0]);
+        System.out.println("nongenerated="+nongenerated[0]);
+        System.out.println("any="+any[0]);
+
+        Assert.assertTrue("Need at least 5000 samples", any[0] >= 5000);
+        Assert.assertTrue("Generated + nongenerated query count should be equal or so to any query count", Math.abs(generated[0]+nongenerated[0]-any[0]) < acceptableThreshold*any[0]);
+        Assert.assertTrue("Generated - nongenerated query count should be zero or so", Math.abs(generated[0]-nongenerated[0]) < acceptableThreshold*any[0]);
+    }
+}

--- a/migrator/src/test/java/com/redhat/lightblue/migrator/WeightsTest.java
+++ b/migrator/src/test/java/com/redhat/lightblue/migrator/WeightsTest.java
@@ -76,7 +76,14 @@ public class WeightsTest {
 
         controller.start();
 
-        Thread.sleep(2500);
+        int loops = 0;
+        while(any[0] < 5000) {
+            Thread.sleep(100);
+
+            if (loops++ > 10000) {
+                throw new RuntimeException("Something's wrong, it shouldn't take that long");
+            }
+        }
 
         controller.setStopped();
 
@@ -88,7 +95,6 @@ public class WeightsTest {
         System.out.println("nongenerated="+nongenerated[0]);
         System.out.println("any="+any[0]);
 
-        Assert.assertTrue("Need at least 5000 samples", any[0] >= 5000);
         Assert.assertTrue("Generated + nongenerated query count should be equal or so to any query count", Math.abs(generated[0]+nongenerated[0]-any[0]) < acceptableThreshold*any[0]);
         Assert.assertTrue("Generated - nongenerated query count should be zero or so", Math.abs(generated[0]-nongenerated[0]) < acceptableThreshold*any[0]);
     }


### PR DESCRIPTION
2 things changed:
* Consistency checker wakes up to generate new jobs regardless of available migration jobs.
* Migrator retrieves either generated or non-generated jobs, according to weights specified in configuration. Migration and consistency checking can run in parallel and their participation can be controlled.

This is not very clean approach, but at least I didn't need to touch the thread management logic, which I find really complex.

TODO: unit test