### PR TITLE
Update timestampInitialValue in the same try-catch block as generated jobs insertion

### DIFF
--- a/migrator/src/main/java/com/redhat/lightblue/migrator/ConsistencyCheckerController.java
+++ b/migrator/src/main/java/com/redhat/lightblue/migrator/ConsistencyCheckerController.java
@@ -13,6 +13,7 @@ import org.joda.time.Period;
 
 import com.redhat.lightblue.client.Query;
 import com.redhat.lightblue.client.Update;
+import com.redhat.lightblue.client.LightblueException;
 import com.redhat.lightblue.client.Literal;
 import com.redhat.lightblue.client.Projection;
 import com.redhat.lightblue.client.util.ClientConstants;
@@ -146,7 +147,7 @@ public class ConsistencyCheckerController extends AbstractController {
         }
     }
 
-    private void batchCreate(List<MigrationJob> mjList) {
+    private void batchCreate(List<MigrationJob> mjList) throws LightblueException {
         final int batchSize = 100;
         List<MigrationJob> batch = new ArrayList<>(batchSize);
         for (MigrationJob mj : mjList) {
@@ -156,11 +157,7 @@ public class ConsistencyCheckerController extends AbstractController {
                 if (!batch.isEmpty()) {
                     DataInsertRequest req = new DataInsertRequest("migrationJob", null);
                     req.create(batch);
-                    try {
-                        lbClient.data(req);
-                    } catch (Exception e) {
-                        LOGGER.error("Exception insering a batch of jobs", e);
-                    }
+                    lbClient.data(req);
                 }
                 batch.clear();
             }
@@ -170,11 +167,7 @@ public class ConsistencyCheckerController extends AbstractController {
             if (!batch.isEmpty()) {
                 DataInsertRequest req = new DataInsertRequest("migrationJob", null);
                 req.create(batch);
-                try {
-                    lbClient.data(req);
-                } catch (Exception e) {
-                    LOGGER.error("Exception insering a batch of jobs", e);
-                }
+                lbClient.data(req);
             }
         }
     }


### PR DESCRIPTION
It is possible for job insertion to fail but timestampInitialValue update to succeed. As a result, some generated jobs may be missing and data for those periods will not be checked for consistency. Those cases are not easy to catch.

To fix this, I'm putting timestampInitialValue update in the same try-catch block as generated jobs insertion. It is still possible that timestampInitialValue update fails after successful job insertion, resulting in job duplicates, but that's better than missing jobs.