### PR TITLE
Logging slow calls also when there is no timeout

### DIFF
--- a/facade/src/main/java/com/redhat/lightblue/migrator/facade/ServiceFacade.java
+++ b/facade/src/main/java/com/redhat/lightblue/migrator/facade/ServiceFacade.java
@@ -136,11 +136,10 @@ public class ServiceFacade<D extends SharedStoreSetter> implements SharedStoreSe
                     return (T) method.invoke(lightblueSvc, values);
                 } finally {
                     long callTook = dest.complete();
-                    long timeout = timeoutConfiguration.getTimeoutMS(method.getName(), op);
                     long slowWarning = timeoutConfiguration.getSlowWarningMS(method.getName(), op);
 
-                    if (callTook >= slowWarning && callTook < timeout) {
-                        // call is slow but not slow enough to trigger timeout
+                    if (callTook >= slowWarning) {
+                        // call is slow; this will log even if source fails to respond
                         log.warn("Slow call warning: {}.{} took {}ms",implementationName, callStringifier.toString(), callTook);
                     }
                 }

--- a/facade/src/main/java/com/redhat/lightblue/migrator/facade/TimeoutConfiguration.java
+++ b/facade/src/main/java/com/redhat/lightblue/migrator/facade/TimeoutConfiguration.java
@@ -43,6 +43,7 @@ public class TimeoutConfiguration {
     public static final String CONFIG_PREFIX = "com.redhat.lightblue.migrator.facade.";
 
     private long defaultTimeoutMS;
+    private long defaultSlowwarnMS;
     private String beanName;
     private Properties properties;
     private boolean interruptOnTimeout = true;
@@ -53,12 +54,15 @@ public class TimeoutConfiguration {
      *
      * @param defaultTimeoutMS Use this timeout if nothing matches in the
      * properties
+     * @param defaultSlowwarnMS Use this slow warn time if nothing matches in
+     * the properties
      * @param beanName bean name to use, e.g. CountryDAO
      * @param properties properties read from a file with timeout settings. Can
      * be null.
      */
-    public TimeoutConfiguration(long defaultTimeoutMS, String beanName, Properties properties) {
+    public TimeoutConfiguration(long defaultTimeoutMS, long defaultSlowwarnMS, String beanName, Properties properties) {
         this.defaultTimeoutMS = defaultTimeoutMS;
+        this.defaultSlowwarnMS = defaultSlowwarnMS;
         this.beanName = beanName;
         if (properties != null) {
             this.properties = properties;
@@ -72,6 +76,18 @@ public class TimeoutConfiguration {
         }
 
         log.info("Initialized TimeoutConfiguration for {}, interruptOnTimeout={}", beanName, interruptOnTimeout);
+    }
+
+    /**
+    *
+    * @param defaultTimeoutMS Use this timeout if nothing matches in the
+    * properties. For defaultSlowwarnMS, it will use 2x defaultTimeoutMS.
+    * @param beanName bean name to use, e.g. CountryDAO
+    * @param properties properties read from a file with timeout settings. Can
+    * be null.
+    */
+    public TimeoutConfiguration(long defaultTimeoutMS, String beanName, Properties properties) {
+        this(defaultTimeoutMS, 2*defaultTimeoutMS, beanName, properties);
     }
 
     /**
@@ -123,7 +139,7 @@ public class TimeoutConfiguration {
                     timeout = defaultTimeoutMS; break;
                 }
                 case slowwarning: {
-                    timeout = 2 * defaultTimeoutMS; break;
+                    timeout = defaultSlowwarnMS; break;
                 }
                 default:
                     throw new IllegalArgumentException("Type " + type + " not known!");

--- a/facade/src/main/java/com/redhat/lightblue/migrator/facade/TimeoutConfiguration.java
+++ b/facade/src/main/java/com/redhat/lightblue/migrator/facade/TimeoutConfiguration.java
@@ -42,8 +42,7 @@ public class TimeoutConfiguration {
 
     public static final String CONFIG_PREFIX = "com.redhat.lightblue.migrator.facade.";
 
-    private long defaultTimeoutMS;
-    private long defaultSlowwarnMS;
+    private final long defaultTimeoutMS, defaultSlowwarnMS;
     private String beanName;
     private Properties properties;
     private boolean interruptOnTimeout = true;
@@ -81,13 +80,14 @@ public class TimeoutConfiguration {
     /**
     *
     * @param defaultTimeoutMS Use this timeout if nothing matches in the
-    * properties. For defaultSlowwarnMS, it will use 2x defaultTimeoutMS.
+    * properties. For defaultSlowwarnMS, it will use defaultTimeoutMS.
+    * (so it doesn't log both timeout and slowwarn unless source is slow)
     * @param beanName bean name to use, e.g. CountryDAO
     * @param properties properties read from a file with timeout settings. Can
     * be null.
     */
     public TimeoutConfiguration(long defaultTimeoutMS, String beanName, Properties properties) {
-        this(defaultTimeoutMS, 2*defaultTimeoutMS, beanName, properties);
+        this(defaultTimeoutMS, defaultTimeoutMS, beanName, properties);
     }
 
     /**

--- a/facade/src/main/java/com/redhat/lightblue/migrator/facade/TimeoutConfiguration.java
+++ b/facade/src/main/java/com/redhat/lightblue/migrator/facade/TimeoutConfiguration.java
@@ -118,7 +118,17 @@ public class TimeoutConfiguration {
                 log.debug("{} config not found for bean {} using global timeout", type, beanName);
             }
 
-            timeout = defaultTimeoutMS;
+            switch (type) {
+                case timeout: {
+                    timeout = defaultTimeoutMS; break;
+                }
+                case slowwarning: {
+                    timeout = 2 * defaultTimeoutMS; break;
+                }
+                default:
+                    throw new IllegalArgumentException("Type " + type + " not known!");
+            }
+
         } else {
             timeout = Long.parseLong(timeoutPropValue);
         }

--- a/facade/src/test/java/com/redhat/lightblue/migrator/facade/TimeoutConfigurationTest.java
+++ b/facade/src/test/java/com/redhat/lightblue/migrator/facade/TimeoutConfigurationTest.java
@@ -76,10 +76,10 @@ public class TimeoutConfigurationTest {
 
         t = new TimeoutConfiguration(2000, "BarService", p);
 
-        Assert.assertEquals(2000, t.getSlowWarningMS("foo", FacadeOperation.READ));
-        Assert.assertEquals(2000, t.getSlowWarningMS("bar", FacadeOperation.WRITE));
-        Assert.assertEquals(2000, t.getSlowWarningMS("fooBar", FacadeOperation.WRITE));
-        Assert.assertEquals(2000, t.getSlowWarningMS("fooBar", FacadeOperation.READ));
+        Assert.assertEquals(4000, t.getSlowWarningMS("foo", FacadeOperation.READ));
+        Assert.assertEquals(4000, t.getSlowWarningMS("bar", FacadeOperation.WRITE));
+        Assert.assertEquals(4000, t.getSlowWarningMS("fooBar", FacadeOperation.WRITE));
+        Assert.assertEquals(4000, t.getSlowWarningMS("fooBar", FacadeOperation.READ));
         Assert.assertEquals(2000, t.getTimeoutMS("fooBar", FacadeOperation.READ));
     }
 

--- a/facade/src/test/java/com/redhat/lightblue/migrator/facade/TimeoutConfigurationTest.java
+++ b/facade/src/test/java/com/redhat/lightblue/migrator/facade/TimeoutConfigurationTest.java
@@ -76,10 +76,10 @@ public class TimeoutConfigurationTest {
 
         t = new TimeoutConfiguration(2000, "BarService", p);
 
-        Assert.assertEquals(4000, t.getSlowWarningMS("foo", FacadeOperation.READ));
-        Assert.assertEquals(4000, t.getSlowWarningMS("bar", FacadeOperation.WRITE));
-        Assert.assertEquals(4000, t.getSlowWarningMS("fooBar", FacadeOperation.WRITE));
-        Assert.assertEquals(4000, t.getSlowWarningMS("fooBar", FacadeOperation.READ));
+        Assert.assertEquals(2000, t.getSlowWarningMS("foo", FacadeOperation.READ));
+        Assert.assertEquals(2000, t.getSlowWarningMS("bar", FacadeOperation.WRITE));
+        Assert.assertEquals(2000, t.getSlowWarningMS("fooBar", FacadeOperation.WRITE));
+        Assert.assertEquals(2000, t.getSlowWarningMS("fooBar", FacadeOperation.READ));
         Assert.assertEquals(2000, t.getTimeoutMS("fooBar", FacadeOperation.READ));
     }
 


### PR DESCRIPTION
Facade will not timeout Lightblue call until source responds successfully. This change logs slow call warning independently of source and can help identify problems in Lightblue when source takes very long to respond or throws an exception.