### PR TITLE
Kinda proxy phase support

### DIFF
--- a/facade/src/test/java/com/redhat/lightblue/migrator/facade/ServiceFacadeTest.java
+++ b/facade/src/test/java/com/redhat/lightblue/migrator/facade/ServiceFacadeTest.java
@@ -197,16 +197,15 @@ public class ServiceFacadeTest {
     }
 
     @Test
-    public void kindaProxyPhaseRead() throws CountryException {
+    public void kindaProxyPhaseReadTest() throws CountryException {
         LightblueMigrationPhase.lightblueKindaProxyPhase(togglzRule);
 
-        Mockito.when(legacyDAO.getCountry("ca")).thenReturn(new Country("ca"));
         Mockito.when(lightblueDAO.getCountry("ca")).thenReturn(new Country("pl"));
 
         Country returnedCountry = countryDAOProxy.getCountry("ca");
 
         Mockito.verify(consistencyChecker, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.any(MethodCallStringifier.class));
-        Mockito.verify(legacyDAO).getCountry("ca");
+        Mockito.verify(legacyDAO, Mockito.times(0)).getCountry("ca");
         Mockito.verify(lightblueDAO).getCountry("ca");
 
         // no consistency check, return data from Lightblue
@@ -214,16 +213,15 @@ public class ServiceFacadeTest {
     }
 
     @Test
-    public void kindaProxyPhaseRead_Null() throws CountryException {
+    public void kindaProxyPhaseReadTestWithNull() throws CountryException {
         LightblueMigrationPhase.lightblueKindaProxyPhase(togglzRule);
 
-        Mockito.when(legacyDAO.getCountry("ca")).thenReturn(new Country("ca"));
         Mockito.when(lightblueDAO.getCountry("ca")).thenReturn(null);
 
         Country returnedCountry = countryDAOProxy.getCountry("ca");
 
         Mockito.verify(consistencyChecker, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.any(MethodCallStringifier.class));
-        Mockito.verify(legacyDAO).getCountry("ca");
+        Mockito.verify(legacyDAO, Mockito.times(0)).getCountry("ca");
         Mockito.verify(lightblueDAO).getCountry("ca");
 
         // no consistency check, return data from Lightblue
@@ -301,6 +299,24 @@ public class ServiceFacadeTest {
         Mockito.verify(consistencyChecker, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.any(MethodCallStringifier.class));
     }
 
+    @Test
+    public void kindaProxyPhaseUpdateTest() throws CountryException {
+        LightblueMigrationPhase.lightblueKindaProxyPhase(togglzRule);
+
+        Country pl = new Country("PL");
+
+        Mockito.when(lightblueDAO.updateCountry(pl)).thenReturn(new Country("pl"));
+
+        Country returnedCountry = countryDAOProxy.updateCountry(pl);
+
+        Mockito.verify(consistencyChecker, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.any(MethodCallStringifier.class));
+        Mockito.verify(legacyDAO).updateCountry(pl);
+        Mockito.verify(lightblueDAO).updateCountry(pl);
+
+        // no consistency check, return data from Lightblue
+        Assert.assertEquals("pl", returnedCountry.getIso2Code());
+    }
+
     /* insert tests */
     @Test
     public void initialPhaseCreate() throws CountryException {
@@ -367,6 +383,24 @@ public class ServiceFacadeTest {
         Mockito.verifyZeroInteractions(legacyDAO);
         Mockito.verify(lightblueDAO).createCountry(pl);
         Mockito.verify(consistencyChecker, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.any(MethodCallStringifier.class));
+    }
+
+    @Test
+    public void kindaProxyPhaseCreateTest() throws CountryException {
+        LightblueMigrationPhase.lightblueKindaProxyPhase(togglzRule);
+
+        Country pl = new Country("PL");
+
+        Mockito.when(lightblueDAO.createCountry(pl)).thenReturn(new Country("pl"));
+
+        Country returnedCountry = countryDAOProxy.createCountry(pl);
+
+        Mockito.verify(consistencyChecker, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.any(MethodCallStringifier.class));
+        Mockito.verify(legacyDAO).createCountry(pl);
+        Mockito.verify(lightblueDAO).createCountry(pl);
+
+        // no consistency check, return data from Lightblue
+        Assert.assertEquals("pl", returnedCountry.getIso2Code());
     }
 
     /* insert tests when method also does a read */
@@ -548,7 +582,6 @@ public class ServiceFacadeTest {
     public void ligtblueFailureDuringRead_KindaProxyPhase() throws CountryException {
         LightblueMigrationPhase.lightblueKindaProxyPhase(togglzRule);
 
-        Mockito.when(legacyDAO.getCountry("ca")).thenReturn(new Country("ca"));
         Mockito.doThrow(new CountryException()).when(lightblueDAO).getCountry("ca");
 
         try {
@@ -556,7 +589,7 @@ public class ServiceFacadeTest {
             Assert.fail("Expected "+CountryException.class);
         } catch (CountryException e) {
             Mockito.verify(consistencyChecker, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.any(MethodCallStringifier.class));
-            Mockito.verify(legacyDAO).getCountry("ca");
+            Mockito.verify(legacyDAO, Mockito.times(0)).getCountry("ca");
             Mockito.verify(lightblueDAO).getCountry("ca");
         }
     }
@@ -1140,13 +1173,13 @@ public class ServiceFacadeTest {
     public void legacyFailureDuringRead_KindaProxyPhase() throws CountryException {
         LightblueMigrationPhase.lightblueKindaProxyPhase(togglzRule);
 
-        Mockito.doThrow(new CountryException()).when(legacyDAO).getCountry("ca");
+        Mockito.doThrow(new CountryException()).when(legacyDAO).getCountry("ca"); // it should not get called anyway...
         Mockito.when(lightblueDAO.getCountry("ca")).thenReturn(new Country("ca"));
 
         Country country = countryDAOProxy.getCountry("ca");
 
         Mockito.verify(consistencyChecker, Mockito.never()).checkConsistency(Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.any(MethodCallStringifier.class));
-        Mockito.verify(legacyDAO).getCountry("ca");
+        Mockito.verify(legacyDAO, Mockito.times(0)).getCountry("ca");
         Mockito.verify(lightblueDAO).getCountry("ca");
 
         // consistency check disabled, legacy exception was swallowed and response from Lightblue returned

--- a/facade/src/test/java/com/redhat/lightblue/migrator/test/LightblueMigrationPhase.java
+++ b/facade/src/test/java/com/redhat/lightblue/migrator/test/LightblueMigrationPhase.java
@@ -56,14 +56,21 @@ public abstract class LightblueMigrationPhase {
     }
 
     /**
-     * Kinda proxy phase is dual read phase with consistency checks disabled.
+     * Kinda proxy phase means:
+     * 1) writes go to both legacy and Lightblue services
+     * 1) reads go only to Lightblue service
+     * 3) consistency checks are disabled
+     *
+     * For write operations, legacy is still going to be called first to ensure all generated data
+     * (ids, timestamps, etc.) can be passed to shared store. Legacy is still the source of this shared information.
+     *
+     * All Lightblue timeouts have to be disabled for kinda proxy phase.
      *
      */
     public static void lightblueKindaProxyPhase(TogglzRule togglzRule) {
-        togglzRule.enable(LightblueMigrationFeatures.READ_SOURCE_ENTITY);
-        togglzRule.enable(LightblueMigrationFeatures.READ_DESTINATION_ENTITY);
         togglzRule.enable(LightblueMigrationFeatures.WRITE_SOURCE_ENTITY);
         togglzRule.enable(LightblueMigrationFeatures.WRITE_DESTINATION_ENTITY);
+        togglzRule.enable(LightblueMigrationFeatures.READ_DESTINATION_ENTITY);
         enableConsistencyChecks(false, togglzRule);
     }
 

--- a/facade/src/test/java/com/redhat/lightblue/migrator/test/LightblueMigrationPhase.java
+++ b/facade/src/test/java/com/redhat/lightblue/migrator/test/LightblueMigrationPhase.java
@@ -56,6 +56,18 @@ public abstract class LightblueMigrationPhase {
     }
 
     /**
+     * Kinda proxy phase is dual read phase with consistency checks disabled.
+     *
+     */
+    public static void lightblueKindaProxyPhase(TogglzRule togglzRule) {
+        togglzRule.enable(LightblueMigrationFeatures.READ_SOURCE_ENTITY);
+        togglzRule.enable(LightblueMigrationFeatures.READ_DESTINATION_ENTITY);
+        togglzRule.enable(LightblueMigrationFeatures.WRITE_SOURCE_ENTITY);
+        togglzRule.enable(LightblueMigrationFeatures.WRITE_DESTINATION_ENTITY);
+        enableConsistencyChecks(false, togglzRule);
+    }
+
+    /**
      *
      * @param togglzRule with all features disabled
      */


### PR DESCRIPTION
Kinda proxy phase means:
1. writes go to both legacy and Lightblue services,
2. if write fails in Lightblue, exception is thrown (in dual read phase it is swallowed!),
3. if write fails in legacy, exception is swallowed (in dual read phase it is thrown!),
4. reads go only to Lightblue service,
5. consistency checks are disabled,
6. all Lightblue timeouts are disabled.

For write operations, legacy is still going to be called first to ensure all generated data (ids, timestamps, etc.) can be passed to shared store. Legacy is still the source of this shared information.

