### PR TITLE
Not using JSON compare for large result sets b/c it consumes a lot of memory

### DIFF
--- a/facade/src/main/java/com/redhat/lightblue/migrator/facade/ServiceFacade.java
+++ b/facade/src/main/java/com/redhat/lightblue/migrator/facade/ServiceFacade.java
@@ -80,7 +80,8 @@ public class ServiceFacade<D extends SharedStoreSetter> implements SharedStoreSe
 
     public ConsistencyChecker getConsistencyChecker() {
         if (consistencyChecker == null) {
-            consistencyChecker = new ConsistencyChecker(implementationName);
+
+            consistencyChecker = new ConsistencyChecker(implementationName, null, getMaxJsonStrLengthForJsonCompare());
         }
         return consistencyChecker;
     }
@@ -115,6 +116,15 @@ public class ServiceFacade<D extends SharedStoreSetter> implements SharedStoreSe
         }
 
         return Long.parseLong(timeout);
+    }
+
+    private Integer getMaxJsonStrLengthForJsonCompare() {
+        String value = properties.getProperty("com.redhat.lightblue.migrator.facade.timeout." + implementationName + ".maxJsonStrLengthForJsonCompare");
+        if (value == null) {
+            return null;
+        }
+
+        return Integer.parseInt(value);
     }
 
     private ListeningExecutorService createExecutor() {

--- a/facade/src/test/java/com/redhat/lightblue/migrator/facade/ConsistencyCheckForHugeDataTest.java
+++ b/facade/src/test/java/com/redhat/lightblue/migrator/facade/ConsistencyCheckForHugeDataTest.java
@@ -1,0 +1,103 @@
+package com.redhat.lightblue.migrator.facade;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.redhat.lightblue.migrator.facade.model.Country;
+
+/**
+ * Tests the logic which uses JSONCompare only for non-huge responses.
+ *
+ * @author mpatercz
+ *
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ConsistencyCheckForHugeDataTest {
+
+    private Logger inconsistencyLog = Mockito.spy(LoggerFactory.getLogger(ConsistencyChecker.class));
+
+    ConsistencyChecker consistencyChecker;
+
+    @Before
+    public void setup() throws InstantiationException, IllegalAccessException {
+        consistencyChecker = new ConsistencyChecker(CountryDAO.class.getSimpleName());
+        consistencyChecker.setInconsistencyLog(inconsistencyLog);
+        consistencyChecker.setMaxJsonStrLengthForJsonCompare(1000);
+    }
+
+    @After
+    public void after() {
+        // no errors logged to inconsistency log
+        Mockito.verify(inconsistencyLog, Mockito.never()).error(Mockito.anyString());
+    }
+
+    @Test
+    public void testSmallDataInconsistencyLogsUsingJsonCompare() {
+        Country pl1 = new Country(1l, "PL");
+
+        Country pl2 = new Country(2l, "PL");
+
+        Assert.assertFalse(consistencyChecker.checkConsistency(pl1, pl2));
+        Mockito.verify(inconsistencyLog, Mockito.times(1)).warn(
+                "[main] Inconsistency found in CountryDAO. - diff: id,Expected: 1,     got: 2, - legacyJson: {\"iso2Code\":\"PL\",\"iso3Code\":null,\"id\":1,\"neighbour\":null,\"allies\":null}, lightblueJson: {\"iso2Code\":\"PL\",\"iso3Code\":null,\"id\":2,\"neighbour\":null,\"allies\":null}"
+                );
+    }
+
+    @Test
+    public void testBigDataInconsistencyLogsUsingJiff() {
+
+        List<Country> countries1 = new ArrayList<>();
+
+        for (long i = 0; i < 100; i++) {
+            countries1.add(new Country(i, "PL" + i));
+        }
+
+        List<Country> countries2 = new ArrayList<>(countries1);
+        countries2.add(new Country(-1l, "PL"));
+        countries1.set(0, new Country(-1l, "PL"));
+
+        Assert.assertFalse(consistencyChecker.checkConsistency(countries1, countries2));
+        ArgumentCaptor<String> loggedWarn = ArgumentCaptor.forClass(String.class);
+        Mockito.verify(inconsistencyLog, Mockito.times(1)).warn(loggedWarn.capture());
+        loggedWarn.getAllValues().get(0).startsWith("[main] Inconsistency found in CountryDAO. - diff: 100(null != {\"iso2Code\":\"PL\",\"iso3Code\":null,\"id\":-1,\"neighbour\":null})");
+    }
+
+    @Test
+    public void testCompareJiffAndJsonCompareArrayElementInconsistencies() {
+        List<Country> countries1 = new ArrayList<>();
+
+        for (long i = 0; i < 100; i++) {
+            countries1.add(new Country(i, "PL" + i));
+        }
+
+        List<Country> countries2 = new ArrayList<>(countries1);
+
+        // create allied country inconsistency
+        countries1.get(0).setAllies(Collections.singletonList(countries1.get(1)));
+        Country c = new Country(0l, "PL0");
+        c.setAllies(Collections.singletonList(countries2.get(2)));
+        countries2.set(0, c);
+
+        Assert.assertFalse(consistencyChecker.checkConsistency(countries1, countries2));
+
+        ArgumentCaptor<String> loggedWarn = ArgumentCaptor.forClass(String.class);
+        Mockito.verify(inconsistencyLog, Mockito.times(1)).warn(loggedWarn.capture());
+
+        System.out.println(loggedWarn.getAllValues().get(0));
+        // json compare diff: [id=0].allies[allies=null].id,Expected: 1,     got: 2, ; [id=0].allies[allies=null].iso2Code,Expected: PL1,     got: PL2,
+        // jiff diff:         0(null != {"iso2Code":"PL0","iso3Code":null,"id":0,"neighbour":null,"allies":[{"iso2Code":"PL2","iso3Code":null,"id":2,"neighbour":null,"allies":null}]}), 0({"iso2Code":"PL0","iso3Code":null,"id":0,"neighbour":null,"allies":[{"iso2Code":"PL1","iso3Code":null,"id":1,"neighbour":null,"allies":null}]} != null)
+    }
+
+}

--- a/facade/src/test/java/com/redhat/lightblue/migrator/facade/model/Country.java
+++ b/facade/src/test/java/com/redhat/lightblue/migrator/facade/model/Country.java
@@ -1,5 +1,7 @@
 package com.redhat.lightblue.migrator.facade.model;
 
+import java.util.List;
+
 import com.google.common.base.Objects;
 
 public class Country {
@@ -8,6 +10,7 @@ public class Country {
     private String iso2Code, iso3Code;
     private Long id;
     private Country neighbour;
+    private List<Country> allies;
 
     public Long getId() {
         return id;
@@ -77,6 +80,14 @@ public class Country {
 
     public void setNeighbour(Country neighbour) {
         this.neighbour = neighbour;
+    }
+
+    public List<Country> getAllies() {
+        return allies;
+    }
+
+    public void setAllies(List<Country> allies) {
+        this.allies = allies;
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <sonar.host.url>http://127.0.0.1:8080</sonar.host.url>
     <sonar.projectName>lightblue-migrator</sonar.projectName>
 
-    <lightblue.client.version>5.10.0-SNAPSHOT</lightblue.client.version>
+    <lightblue.client.version>5.10.0</lightblue.client.version>
   </properties>
   <dependencyManagement>
     <dependencies>


### PR DESCRIPTION
Service facade uses 2 libraries to diff api responses: JSONCompare and Jiff. Jiff is faster and consumes less memory, but provides less details (stops on first diff encountered and does not describe array element differences). This change will use JSONCompare to report for all responses under 65kB and Jiff for bigger ones (configurable).