### PR TITLE
Adding Migrator.beforeSaveToDestination

### DIFF
--- a/migrator/src/main/java/com/redhat/lightblue/migrator/Migrator.java
+++ b/migrator/src/main/java/com/redhat/lightblue/migrator/Migrator.java
@@ -104,6 +104,21 @@ public abstract class Migrator extends AbstractMonitoredThread {
         return getMigrationConfiguration().getDestinationIdentityFields();
     }
 
+    /**
+     * Execute this method before docs are saved to destination (Lightblue). Modifying saveDocsList
+     * will affect what gets actually saved. Implementation of this method is responsible for exception handling.
+     *
+     * @param sourceDocs docs read from source
+     * @param destDocs corresponding docs read from destination
+     * @param insertDocs docs which exist in source but not in destination
+     * @param rewriteDocs docs which existing in both source and destination, but are different
+     * @param saveDocsList list of docs to save
+     */
+    protected void beforeSaveToDestination(Map<Identity, JsonNode> sourceDocs, Map<Identity, JsonNode> destDocs, Set<Identity> insertDocs, Set<Identity> rewriteDocs, List<JsonNode> saveDocsList) {
+        // do nothing by default
+        // override this in child classes to get access to docs before they are saved
+    }
+
     public void migrate(MigrationJobExecution execution) {
         try {
             ping("Starting migrate()");
@@ -176,6 +191,7 @@ public abstract class Migrator extends AbstractMonitoredThread {
             execution.setProcessedDocumentCount(sourceDocs.size());
 
             LOGGER.debug("There are {} docs to save: {}", saveDocsList.size(), migrationJob.getConfigurationName());
+            beforeSaveToDestination(sourceDocs, destDocs, insertDocs, rewriteDocs, saveDocsList);
             try {
                 List<LightblueResponse> responses = save(saveDocsList);
                 ping("Saved documents");

--- a/migrator/src/test/java/com/redhat/lightblue/migrator/MigratorTest.java
+++ b/migrator/src/test/java/com/redhat/lightblue/migrator/MigratorTest.java
@@ -90,7 +90,7 @@ public class MigratorTest extends AbstractMigratorController {
                 getMigrationProcesses().
                 get("customerMigration_0").mig.getMigratorThreads().enumerate(threads));
 
-        Migrator m = (Migrator) threads[0];
+        TestMigrator m = (TestMigrator) threads[0];
         Assert.assertEquals(5, m.getSourceDocs().size());
 
         Breakpoint.stop("Migrator:complete");
@@ -117,6 +117,12 @@ public class MigratorTest extends AbstractMigratorController {
         controller.setStopped();
         System.out.println("Test ends");
         Thread.sleep(1000);
+
+        Assert.assertEquals(5, m.sourceDocs.size());
+        Assert.assertEquals(0, m.destDocs.size());
+        Assert.assertEquals(5, m.insertDocs.size());
+        Assert.assertEquals(0, m.rewriteDocs.size());
+        Assert.assertEquals(5, m.saveDocsList.size());
     }
 
     @Test

--- a/migrator/src/test/java/com/redhat/lightblue/migrator/TestMigrator.java
+++ b/migrator/src/test/java/com/redhat/lightblue/migrator/TestMigrator.java
@@ -1,0 +1,30 @@
+package com.redhat.lightblue.migrator;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+public class TestMigrator extends DefaultMigrator {
+
+    public Map<Identity, JsonNode> sourceDocs, destDocs;
+    public Set<Identity> insertDocs, rewriteDocs;
+    public List<JsonNode> saveDocsList;
+
+    public TestMigrator(ThreadGroup grp) {
+        super(grp);
+    }
+
+    @Override
+    protected void beforeSaveToDestination(Map<Identity, JsonNode> sourceDocs, Map<Identity, JsonNode> destDocs, Set<Identity> insertDocs,
+            Set<Identity> rewriteDocs, List<JsonNode> saveDocsList) {
+
+        this.sourceDocs = sourceDocs;
+        this.destDocs = destDocs;
+        this.insertDocs = insertDocs;
+        this.rewriteDocs = rewriteDocs;
+        this.saveDocsList = saveDocsList;
+    }
+
+}

--- a/migrator/src/test/resources/test/data/load-migration-configurations.json
+++ b/migrator/src/test/resources/test/data/load-migration-configurations.json
@@ -18,7 +18,7 @@
             "sourceEntityName": "sourceCustomer", 
             "sourceEntityVersion": "1.0.0", 
             "sourceServiceURI": "https://localhost/rest/data", 
-            "migratorClass": "com.redhat.lightblue.migrator.DefaultMigrator", 
+            "migratorClass": "com.redhat.lightblue.migrator.TestMigrator",
             "threadCount": 1
         }
     ]


### PR DESCRIPTION
Allows migrator implementations to see which documents are going to be overwritten and which are going to be inserted. Use case: additional logging for missing documents (ones getting inserted) matching certain criteria.

