### PR TITLE
When lightblue impl call times out, still log the error if any

### DIFF
--- a/facade/src/main/java/com/redhat/lightblue/migrator/facade/SwallowableException.java
+++ b/facade/src/main/java/com/redhat/lightblue/migrator/facade/SwallowableException.java
@@ -1,0 +1,21 @@
+package com.redhat.lightblue.migrator.facade;
+
+/**
+ * A wrapper around exceptions indicating if they should be swallowed by the facade.
+ * Swallowing means logging the exception and fail-overing to source implementation result.
+ *
+ * @author mpatercz
+ *
+ */
+public class SwallowableException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    public final boolean swallow;
+
+    public SwallowableException(Throwable cause, boolean swallow) {
+        super(cause);
+        this.swallow = swallow;
+    }
+
+}


### PR DESCRIPTION
If lightblue impl call times out, only the timeout event is logged. If the timed out thread eventually throws an exception (which can be explain why the call takes long, e.g. can't reach db), it is silently swallowed by the facade. This change prevents that.