### PR TITLE
Adding an option to ignore ms different on timestamps

### DIFF
--- a/migrator/src/main/java/com/redhat/lightblue/migrator/MigrationConfiguration.java
+++ b/migrator/src/main/java/com/redhat/lightblue/migrator/MigrationConfiguration.java
@@ -28,6 +28,7 @@ public class MigrationConfiguration {
     private String sourceServiceURI;
     private String sourceEntityName;
     private String sourceEntityVersion;
+    private boolean ignoreTimestampMSDiffs = false;
 
     private String timestampFieldName;
     private Date timestampInitialValue;
@@ -453,5 +454,13 @@ public class MigrationConfiguration {
     @JsonIgnore
     public void setSleepIfNoJobs(boolean sleepIfNoJobs) {
         this.sleepIfNoJobs = sleepIfNoJobs;
+    }
+
+    public boolean isIgnoreTimestampMSDiffs() {
+        return ignoreTimestampMSDiffs;
+    }
+
+    public void setIgnoreTimestampMSDiffs(boolean ignoreTimestampMSDiffs) {
+        this.ignoreTimestampMSDiffs = ignoreTimestampMSDiffs;
     }
 }

--- a/migrator/src/main/java/com/redhat/lightblue/migrator/Migrator.java
+++ b/migrator/src/main/java/com/redhat/lightblue/migrator/Migrator.java
@@ -148,7 +148,9 @@ public abstract class Migrator extends AbstractMonitoredThread {
             for (Map.Entry<Identity, JsonNode> sourceEntry : sourceDocs.entrySet()) {
                 JsonNode destDoc = destDocs.get(sourceEntry.getKey());
                 if (destDoc != null) {
-                    List<Inconsistency> inconsistencies = Utils.compareDocs(sourceEntry.getValue(), destDoc, getMigrationConfiguration().getComparisonExclusionPaths());
+                    List<Inconsistency> inconsistencies = Utils.compareDocs(sourceEntry.getValue(), destDoc,
+                            getMigrationConfiguration().getComparisonExclusionPaths(),
+                            getMigrationConfiguration().isIgnoreTimestampMSDiffs());
                     if (inconsistencies != null && !inconsistencies.isEmpty()) {
                         rewriteDocs.add(sourceEntry.getKey());
                         // log as key=value to make parsing easy

--- a/migrator/src/main/resources/migrationConfiguration.json
+++ b/migrator/src/main/resources/migrationConfiguration.json
@@ -5,7 +5,7 @@
             "collection": "migrationConfiguration",
             "datasource": "mongodata"
         },
-        "defaultVersion" : "2.0.2",
+        "defaultVersion" : "2.0.3",
         "indexes": [
             {
                 "fields": [
@@ -154,6 +154,10 @@
                 },
                 "description": "identity fields in the destination entity."
             },
+            "ignoreTimestampMSDiffs": {
+                "type": "boolean",
+                "description": "If true, 20071203T10:15:30.000-0400 == 20071203T10:15:30.123-0400"
+            },
             "sourceConfigPath": {
                 "type":"string"
             },
@@ -193,8 +197,8 @@
             "value": "active"
         },
         "version": {
-            "changelog": "Weights for migrator and consistency checker",
-            "value": "2.0.2"
+            "changelog": "Adding ignoreTimestampMSDiffs",
+            "value": "2.0.3"
         }
     }
 }

--- a/migrator/src/test/java/com/redhat/lightblue/migrator/CompareTest.java
+++ b/migrator/src/test/java/com/redhat/lightblue/migrator/CompareTest.java
@@ -1,15 +1,14 @@
 package com.redhat.lightblue.migrator;
 
-import java.util.List;
 import java.util.ArrayList;
+import java.util.List;
 
-import org.junit.Test;
 import org.junit.Assert;
-import org.junit.Before;
-import org.junit.After;
+import org.junit.Test;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.*;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 public class CompareTest {
 
@@ -20,9 +19,9 @@ public class CompareTest {
         n1.set("a", JsonNodeFactory.instance.numberNode(1));
         n2.set("a", JsonNodeFactory.instance.numberNode(1));
         n1.set("a#", JsonNodeFactory.instance.numberNode(1));
-        List<Inconsistency> list = Utils.compareDocs(n1, n2, new ArrayList<String>());
+        List<Inconsistency> list = Utils.compareDocs(n1, n2, new ArrayList<String>(), false);
         Assert.assertTrue(list.isEmpty());
-        list = Utils.compareDocs(n2, n1, new ArrayList<String>());
+        list = Utils.compareDocs(n2, n1, new ArrayList<String>(), false);
         Assert.assertTrue(list.isEmpty());
     }
 
@@ -44,10 +43,31 @@ public class CompareTest {
         x2.set("y", JsonNodeFactory.instance.textNode("y"));
         a2.add(x2);
 
-        List<Inconsistency> list = Utils.compareDocs(n1, n2, new ArrayList<String>());
+        List<Inconsistency> list = Utils.compareDocs(n1, n2, new ArrayList<String>(), false);
         System.out.println(list);
         Assert.assertEquals(1, list.size());
         Assert.assertEquals("arr.0.x", list.get(0).getField());
+    }
+
+    @Test
+    public void testDatesWhichDifferByMS() {
+        ObjectNode n1 = JsonNodeFactory.instance.objectNode();
+        ObjectNode n2 = JsonNodeFactory.instance.objectNode();
+
+        n1.put("timestamp", "20071203T10:15:30.000-0400");
+        n2.put("timestamp", "20071203T10:15:30.015-0400");
+
+        List<Inconsistency> list = Utils.compareDocs(n1, n2, new ArrayList<String>(), false);
+        Assert.assertEquals(1, list.size());
+
+        list = Utils.compareDocs(n1, n2, new ArrayList<String>(), true);
+        Assert.assertEquals(0, list.size());
+
+        n1.put("timestamp", "20071203T10:15:30.000-0400");
+        n2.put("timestamp", "20071203T10:15:29.999-0400");
+
+        list = Utils.compareDocs(n1, n2, new ArrayList<String>(), true);
+        Assert.assertEquals(1, list.size());
     }
 
 }


### PR DESCRIPTION
When source has lower timestamp precision than destination, we get lots of false inconsistencies. This change addresses that (for precision difference in milliseconds). By default, behavior is not changing.